### PR TITLE
⚡ Bolt: Optimize stderr processing in NATS server

### DIFF
--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -78,7 +78,14 @@ export class NatsServer {
         reject(err);
       });
 
+      let isReady = false;
+
       this.process.stderr.on(`data`, (data: unknown) => {
+        // Optimization: skip processing logs if not verbose and server is already ready
+        if (!verbose && isReady) {
+          return;
+        }
+
         // eslint-disable-next-line @typescript-eslint/no-base-to-string
         const dataStr = data?.toString();
 
@@ -87,6 +94,8 @@ export class NatsServer {
         }
 
         if (dataStr?.includes(`Server is ready`) === true) {
+          isReady = true;
+
           if (verbose) {
             logger.log(`NATS server is ready!`);
           }


### PR DESCRIPTION
💡 What: Optimized the `stderr` event listener in `src/nats-server.ts` to skip processing log data once the server has successfully started, specifically when `verbose` mode is disabled.

🎯 Why: The original implementation converted every `stderr` chunk to a string and checked if it included "Server is ready", even after the server was already running. This created unnecessary CPU overhead and garbage collection pressure for every log line generated by the NATS server.

📊 Impact: Reduces CPU usage and memory allocation by avoiding buffer-to-string conversions and string searches for every log message after startup in non-verbose mode.

🔬 Measurement: Verify by running `npm test` and ensuring the server still starts up correctly and logs are suppressed when verbose is false (though tests run with verbose=true). The optimization logic can be verified by code inspection.

---
*PR created automatically by Jules for task [12101454905137639997](https://jules.google.com/task/12101454905137639997) started by @ll1r1k-1337*