### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Zip Slip / Path Traversal in downloadFile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal
+
+## 2026-02-10 - Zip Slip / Path Traversal in File Download
+**Vulnerability:** The `downloadFile` function blindly trusted the `Content-Disposition` header's filename, allowing an attacker (or compromised server) to overwrite arbitrary files on the system via path traversal characters (e.g., `../../../etc/passwd`).
+**Learning:** `path.resolve` treats `..` components as directory traversal instructions, even if they originate from untrusted string input. Native `split` on headers is insufficient for security.
+**Prevention:** Always sanitize filenames from external sources using `path.basename()` to strip directory components. Additionally, verify that the final resolved path lies within the intended target directory using `path.relative()` checks.


### PR DESCRIPTION
This PR fixes a Critical Zip Slip / Path Traversal vulnerability in the `downloadFile` utility.

**Vulnerability:**
The `downloadFile` function previously trusted the filename provided in the `Content-Disposition` header without sufficient sanitization. A malicious server (or compromised download URL) could provide a filename with directory traversal characters (e.g., `../../../etc/passwd`), allowing arbitrary file overwrite on the host system.

**Fix:**
1.  **Sanitization:** The filename is now sanitized using `path.basename()` to strip all directory components.
2.  **Verification:** The code now explicitly checks that the resolved destination path is contained within the intended download directory using `path.relative()`.
3.  **Parsing:** The `Content-Disposition` header parsing was improved to correctly handle quoted filenames and extra parameters.

**Verification:**
- Added a new test suite `src/utils/download-file.spec.ts` covering:
    - Normal file download.
    - Path traversal attempts (verified to be sanitized).
    - Proxy configuration (restored tests).
    - Missing filename handling.
- Ran `reproduce_vuln.spec.ts` (local reproduction script) which confirmed the vulnerability was present before the fix and mitigated after.
- Ran full test suite (`npm test`) to ensure no regressions.

**Impact:**
Prevents potential RCE or file system corruption via malicious file downloads. This is especially critical if the user configures a custom `downloadUrl` or if the default download source is compromised.

---
*PR created automatically by Jules for task [18319095925102669914](https://jules.google.com/task/18319095925102669914) started by @ll1r1k-1337*