### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal Vulnerability in downloadFile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Journal
+
+## 2024-02-11 - Path Traversal in File Download
+**Vulnerability:** The `downloadFile` utility directly used filenames from `Content-Disposition` headers without sanitization, allowing path traversal attacks via `../../` sequences.
+**Learning:** Mocking the `path` module in unit tests masked this vulnerability because the mock didn't implement real path resolution logic. Security-critical file operations should use integration-style tests with real filesystem/path modules to verify path boundaries.
+**Prevention:** Always use `path.basename()` on user-provided filenames to strip directory components and verify the resolved destination path is within the expected target directory using `startsWith()` or similar checks.

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -1,0 +1,79 @@
+import { downloadFile } from './download-file';
+import fetch from 'make-fetch-happen';
+import fs from 'fs';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+
+jest.mock('make-fetch-happen');
+jest.mock('fs');
+jest.mock('stream/promises');
+
+// We do NOT mock path here to test actual path resolution
+// or we can just inspect what path.resolve receives if we mock it.
+// But to be 100% sure about "traversal", using real path is better.
+// However, the original test mocks it.
+// Let's mock path but check arguments to ensure sanitization.
+
+describe('downloadFile Security', () => {
+  const mockFetch = fetch as unknown as jest.Mock;
+  const mockPipeline = pipeline as unknown as jest.Mock;
+  const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should prevent path traversal in filename', async () => {
+    const url = 'http://example.com/malicious.zip';
+    const dir = './downloads';
+
+    // Malicious filename attempting to traverse up
+    const maliciousFilename = '../../../../etc/passwd';
+
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename=${maliciousFilename}`),
+      },
+      body: 'mockBody',
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue('mockWriteStream');
+    mockPipeline.mockResolvedValue(undefined);
+
+    // We expect the function to either throw or sanitize the path.
+    // If it uses path.resolve(dir, maliciousFilename), the result will be outside dir.
+
+    // We can spy on fs.createWriteStream to see where it tries to write.
+
+    await downloadFile(url, dir);
+
+    const writeCall = mockCreateWriteStream.mock.calls[0];
+    const destinationPath = writeCall[0];
+
+    // Check if the destination path ends with the malicious traversal
+    // With real path.resolve, it would be resolved.
+    // But since we are importing the module which imports 'path',
+    // and we haven't mocked 'path' in THIS test file (only in the other one),
+    // it should use the real path module.
+
+    const resolvedDir = path.resolve(dir);
+    // verification: destination should be inside resolvedDir
+
+    // If vulnerable, destinationPath will be /etc/passwd (or relative equivalent)
+    // If secure, it should be resolvedDir/passwd
+
+    console.log('Destination:', destinationPath);
+    console.log('Resolved Dir:', resolvedDir);
+
+    const isChild = destinationPath.startsWith(resolvedDir);
+    if (!isChild) {
+      throw new Error(
+        `Path traversal detected! Wrote to ${destinationPath} which is not inside ${resolvedDir}`,
+      );
+    }
+  });
+});

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -4,9 +4,9 @@ import fs from 'fs';
 import path from 'path';
 import { pipeline } from 'stream/promises';
 
-jest.mock('make-fetch-happen');
-jest.mock('fs');
-jest.mock('stream/promises');
+jest.mock(`make-fetch-happen`);
+jest.mock(`fs`);
+jest.mock(`stream/promises`);
 
 // We do NOT mock path here to test actual path resolution
 // or we can just inspect what path.resolve receives if we mock it.
@@ -14,7 +14,7 @@ jest.mock('stream/promises');
 // However, the original test mocks it.
 // Let's mock path but check arguments to ensure sanitization.
 
-describe('downloadFile Security', () => {
+describe(`downloadFile Security`, () => {
   const mockFetch = fetch as unknown as jest.Mock;
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
@@ -23,12 +23,12 @@ describe('downloadFile Security', () => {
     jest.clearAllMocks();
   });
 
-  it('should prevent path traversal in filename', async () => {
-    const url = 'http://example.com/malicious.zip';
-    const dir = './downloads';
+  it(`should prevent path traversal in filename`, async () => {
+    const url = `http://example.com/malicious.zip`;
+    const dir = `./downloads`;
 
     // Malicious filename attempting to traverse up
-    const maliciousFilename = '../../../../etc/passwd';
+    const maliciousFilename = `../../../../etc/passwd`;
 
     const mockResponse = {
       ok: true,
@@ -37,11 +37,11 @@ describe('downloadFile Security', () => {
           .fn()
           .mockReturnValue(`attachment; filename=${maliciousFilename}`),
       },
-      body: 'mockBody',
+      body: `mockBody`,
     };
 
     mockFetch.mockResolvedValue(mockResponse);
-    mockCreateWriteStream.mockReturnValue('mockWriteStream');
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
     mockPipeline.mockResolvedValue(undefined);
 
     // We expect the function to either throw or sanitize the path.
@@ -66,14 +66,17 @@ describe('downloadFile Security', () => {
     // If vulnerable, destinationPath will be /etc/passwd (or relative equivalent)
     // If secure, it should be resolvedDir/passwd
 
-    console.log('Destination:', destinationPath);
-    console.log('Resolved Dir:', resolvedDir);
+    console.log(`Destination:`, destinationPath);
+    console.log(`Resolved Dir:`, resolvedDir);
 
-    const isChild = destinationPath.startsWith(resolvedDir);
+    const isChild = (destinationPath as string).startsWith(resolvedDir);
     if (!isChild) {
       throw new Error(
-        `Path traversal detected! Wrote to ${destinationPath} which is not inside ${resolvedDir}`,
+        `Path traversal detected! Wrote to ${String(
+          destinationPath,
+        )} which is not inside ${resolvedDir}`,
       );
     }
+    expect(isChild).toBe(true);
   });
 });

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,9 +14,11 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockBasename.mockReturnValue('file.zip');
   });
 
   it(`should download a file successfully`, async () => {
@@ -33,6 +35,7 @@ describe(`downloadFile`, () => {
 
     mockFetch.mockResolvedValue(mockResponse);
     mockResolve.mockReturnValue(destination);
+    mockBasename.mockReturnValue('file.zip');
     mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
     mockPipeline.mockResolvedValue(undefined);
 

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -18,7 +18,7 @@ describe(`downloadFile`, () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockBasename.mockReturnValue('file.zip');
+    mockBasename.mockReturnValue(`file.zip`);
   });
 
   it(`should download a file successfully`, async () => {
@@ -35,7 +35,7 @@ describe(`downloadFile`, () => {
 
     mockFetch.mockResolvedValue(mockResponse);
     mockResolve.mockReturnValue(destination);
-    mockBasename.mockReturnValue('file.zip');
+    mockBasename.mockReturnValue(`file.zip`);
     mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
     mockPipeline.mockResolvedValue(undefined);
 

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -43,7 +43,7 @@ export async function downloadFile(
     throw new Error(`No filename in content-disposition`);
   }
 
-  const fileName = path.basename(rawFileName.replace(/["';]/g, '').trim());
+  const fileName = path.basename(rawFileName.replace(/["';]/g, ``).trim());
   const destination = path.resolve(dir, fileName);
 
   if (!destination.startsWith(path.resolve(dir))) {


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix Path Traversal Vulnerability

🚨 Severity: HIGH
💡 Vulnerability: The `downloadFile` utility was vulnerable to path traversal attacks because it trusted the filename provided in the `Content-Disposition` header without sanitization. An attacker could provide a filename like `../../etc/passwd` to overwrite arbitrary files on the system.
🎯 Impact: Arbitrary file overwrite, potentially leading to remote code execution or denial of service.
🔧 Fix:
    - Sanitize the extracted filename using `path.basename()` to remove directory components.
    - Verify that the resolved destination path starts with the resolved target directory path using `startsWith()`.
    - Improve basic cleanup of the filename string (removing quotes/semicolons).
✅ Verification:
    - Added a reproduction test case `src/utils/download-file.security.spec.ts` that attempts to write outside the target directory.
    - Verified that the fix prevents the traversal and the test passes.
    - Verified that existing functionality (downloading files) still works with `src/utils/download-file.spec.ts`.

---
*PR created automatically by Jules for task [11659158648696465806](https://jules.google.com/task/11659158648696465806) started by @ll1r1k-1337*