### PR TITLE
🛡️ Sentinel: Fix Path Traversal in File Download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-12 - Path Traversal in File Download
+**Vulnerability:** The `downloadFile` function blindly trusted the `Content-Disposition` header filename from the server, allowing path traversal attacks if a malicious server or URL was configured.
+**Learning:** Never trust input from external sources, even from headers like `Content-Disposition`. Developers often overlook filename sanitization when downloading files, assuming the URL source is trusted or benign.
+**Prevention:** Always sanitize filenames using `path.basename()` before using them in file system operations. Ensure the resolved path is within the intended directory using `path.resolve` and checking if it starts with the target directory path.

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -1,0 +1,54 @@
+import { downloadFile } from './download-file';
+import fetch from 'make-fetch-happen';
+import fs from 'fs';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+
+jest.mock(`make-fetch-happen`);
+jest.mock(`fs`);
+jest.mock(`stream/promises`);
+
+// We do NOT mock path here because we want to test the path resolution logic
+// jest.mock('path');
+
+describe(`downloadFile - Security Tests`, () => {
+  const mockFetch = fetch as unknown as jest.Mock;
+  const mockPipeline = pipeline as unknown as jest.Mock;
+  const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`should prevent path traversal by sanitizing filename`, async () => {
+    const url = `http://example.com/malicious.zip`;
+    const dir = `/tmp/safe-dir`;
+    const maliciousFilename = `../../../../etc/passwd`;
+
+    // The vulnerable code would resolve to /etc/passwd
+    // The fixed code should resolve to /tmp/safe-dir/passwd (basename of maliciousFilename is passwd)
+
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename=${maliciousFilename}`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    const result = await downloadFile(url, dir);
+
+    // Expect the path to be sanitized
+    const safeFilename = path.basename(maliciousFilename);
+    const expectedPath = path.resolve(dir, safeFilename);
+
+    expect(result).toBe(expectedPath);
+    expect(mockCreateWriteStream).toHaveBeenCalledWith(expectedPath);
+  });
+});

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,9 +14,11 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockBasename.mockReturnValue(`file.zip`);
   });
 
   it(`should download a file successfully`, async () => {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,14 +36,15 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
+  const rawFileName = response.headers
     .get(CONTENT_DISPOSITION_KEY)
     ?.split(`filename=`)?.[1];
 
-  if (fileName == null) {
+  if (rawFileName == null) {
     throw new Error(`No filename in content-disposition`);
   }
 
+  const fileName = path.basename(rawFileName);
   const destination = path.resolve(dir, fileName);
   const fileStream = createWriteStream(destination);
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Path Traversal Vulnerability

🚨 Severity: CRITICAL
💡 Vulnerability: The `downloadFile` function blindly trusted the `Content-Disposition` header filename from the server. If a malicious server (or a user-configured URL) returned a filename with directory traversal characters (e.g., `../../etc/passwd`), it would allow writing files outside the intended download directory.
🎯 Impact: Arbitrary File Write. An attacker could overwrite critical system files or inject code if they can control the download URL or if the configured download server is compromised.
🔧 Fix: Used `path.basename()` to strip any directory components from the filename before resolving the destination path.
✅ Verification: Added a regression test `src/utils/download-file.security.spec.ts` that attempts a path traversal attack and asserts that the file is written to the sanitized path instead of the traversed path. Also verified that existing tests pass with the updated mock.

---
*PR created automatically by Jules for task [15102840562828401996](https://jules.google.com/task/15102840562828401996) started by @ll1r1k-1337*