### PR TITLE
⚡ Bolt: optimize nats-server stderr listener

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-02-14 - Stderr Stream Optimization
+**Learning:** Consuming `stderr` or `stdout` streams with expensive operations (like `toString()`) in a `data` listener can add significant CPU overhead, especially if the stream is chatty or if the operation is unnecessary after a certain state (like startup readiness).
+**Action:** When monitoring streams for a specific condition (e.g., "Server is ready"), introduce a state flag (e.g., `isReady`) to bypass the expensive checks once the condition is met. If the data is not needed afterwards (e.g., logging is disabled), return early to avoid processing altogether.

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -78,7 +78,14 @@ export class NatsServer {
         reject(err);
       });
 
+      let isReady = false;
+
       this.process.stderr.on(`data`, (data: unknown) => {
+        // Bolt: optimization to avoid unnecessary string conversion and checks after server is ready
+        if (!verbose && isReady) {
+          return;
+        }
+
         // eslint-disable-next-line @typescript-eslint/no-base-to-string
         const dataStr = data?.toString();
 
@@ -86,7 +93,9 @@ export class NatsServer {
           logger.log(dataStr);
         }
 
-        if (dataStr?.includes(`Server is ready`) === true) {
+        if (!isReady && dataStr?.includes(`Server is ready`) === true) {
+          isReady = true;
+
           if (verbose) {
             logger.log(`NATS server is ready!`);
           }


### PR DESCRIPTION
💡 What: Implemented an optimization in the `NatsServer` `stderr` listener.
🎯 Why: To reduce CPU overhead caused by converting `stderr` buffer to string and checking for "Server is ready" on every log message, even after the server has started.
📊 Impact: Eliminates unnecessary string allocation and processing for every log line after startup. Significant reduction in overhead when `verbose` is disabled.
🔬 Measurement: Verified by logic analysis and running existing tests to ensure no regressions. Tests pass.


---
*PR created automatically by Jules for task [5720282821119083003](https://jules.google.com/task/5720282821119083003) started by @ll1r1k-1337*