### PR TITLE
🛡️ Sentinel: Fix Path Traversal in File Download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-15 - [Path Traversal in File Download]
+**Vulnerability:** The `downloadFile` utility extracted filenames from the `Content-Disposition` header using simple string splitting and used them directly in `path.resolve` without sanitization. This allowed a malicious server (or compromised URL) to write files outside the intended directory using path traversal characters (e.g., `filename=../../etc/passwd`).
+**Learning:** Never trust filenames provided by external sources, including HTTP headers. `path.resolve` resolves `..` segments, which can escape the intended directory.
+**Prevention:** Always sanitize filenames (e.g., using `path.basename`) and validate that the resolved destination path resides within the intended target directory before writing files.

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -1,0 +1,84 @@
+import { downloadFile } from './download-file';
+import fetch from 'make-fetch-happen';
+import fs from 'fs';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+
+// Mock make-fetch-happen
+jest.mock(`make-fetch-happen`, () => jest.fn());
+
+// Mock fs module partially
+jest.mock(`fs`, () => ({
+  createWriteStream: jest.fn(),
+  promises: {
+    readFile: jest.fn(),
+  },
+}));
+
+// Mock stream/promises
+jest.mock(`stream/promises`, () => ({
+  pipeline: jest.fn(),
+}));
+
+describe(`downloadFile Security`, () => {
+  const mockFetch = fetch as unknown as jest.Mock;
+  const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
+  const mockPipeline = pipeline as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`should sanitize path traversal attempts via Content-Disposition filename`, async () => {
+    const url = `http://example.com/malicious.zip`;
+    const dir = path.resolve(`/tmp/safe-dir`);
+    const maliciousFilename = `../../etc/passwd`;
+
+    // Setup the mock response with malicious filename
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename=${maliciousFilename}`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue({});
+    mockPipeline.mockResolvedValue(undefined);
+
+    const result = await downloadFile(url, dir);
+
+    // With basename sanitization, ../../etc/passwd becomes passwd
+    const expectedPath = path.resolve(dir, `passwd`);
+
+    expect(result).toBe(expectedPath);
+    expect(result.startsWith(dir)).toBe(true);
+  });
+
+  it(`should reject filenames that resolve outside the target directory (e.g., "..")`, async () => {
+    const url = `http://example.com/malicious.zip`;
+    const dir = path.resolve(`/tmp/safe-dir`);
+    const maliciousFilename = `..`;
+
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename=${maliciousFilename}`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue({});
+    mockPipeline.mockResolvedValue(undefined);
+
+    await expect(downloadFile(url, dir)).rejects.toThrow(
+      `Invalid filename: Path traversal detected`,
+    );
+  });
+});

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -6,7 +6,10 @@ import { pipeline } from 'stream/promises';
 
 jest.mock(`make-fetch-happen`);
 jest.mock(`fs`);
-jest.mock(`path`);
+jest.mock(`path`, () => ({
+  resolve: jest.fn(),
+  basename: jest.fn((p) => p),
+}));
 jest.mock(`stream/promises`);
 
 describe(`downloadFile`, () => {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,7 +36,7 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
+  let fileName = response.headers
     .get(CONTENT_DISPOSITION_KEY)
     ?.split(`filename=`)?.[1];
 
@@ -44,7 +44,12 @@ export async function downloadFile(
     throw new Error(`No filename in content-disposition`);
   }
 
+  fileName = path.basename(fileName);
   const destination = path.resolve(dir, fileName);
+
+  if (!destination.startsWith(path.resolve(dir))) {
+    throw new Error(`Invalid filename: Path traversal detected`);
+  }
   const fileStream = createWriteStream(destination);
 
   await pipeline(response.body, fileStream);


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Download

🚨 Severity: CRITICAL
💡 Vulnerability: The `downloadFile` utility extracted filenames from the `Content-Disposition` header using simple string splitting and used them directly in `path.resolve` without sanitization. This allowed a malicious server (or compromised URL) to write files outside the intended directory using path traversal characters (e.g., `filename=../../etc/passwd`).
🎯 Impact: Arbitrary file overwrite, potentially leading to RCE or system compromise.
🔧 Fix: Used `path.basename` to strip directory components from the filename and added a check to ensure the resolved destination path starts with the resolved target directory path.
✅ Verification: Added a new security test `src/utils/download-file.security.spec.ts` that attempts path traversal and asserts it is sanitized or rejected. Verified full test suite passes.

---
*PR created automatically by Jules for task [7701200134077345462](https://jules.google.com/task/7701200134077345462) started by @ll1r1k-1337*