### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-16 - [Path Traversal in File Download]
+**Vulnerability:** Naive extraction of `filename` from `Content-Disposition` header allowed path traversal (e.g. `../../etc/passwd`).
+**Learning:** `Content-Disposition` header values are untrusted input. The standard library `path.resolve` does not sanitize traversal characters.
+**Prevention:** Always use `path.basename` on filenames from external sources before using them in file system operations. Also, verify the resolved path starts with the intended directory using `startsWith` as a defense-in-depth measure.

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -4,14 +4,14 @@ import fs from 'fs';
 import path from 'path';
 import { pipeline } from 'stream/promises';
 
-jest.mock('make-fetch-happen');
-jest.mock('fs');
-jest.mock('stream/promises');
+jest.mock(`make-fetch-happen`);
+jest.mock(`fs`);
+jest.mock(`stream/promises`);
 
 // We want to test path resolution, so we DON'T mock path completely
 // but we might want to spy on it if needed. For now, using actual path is better.
 
-describe('downloadFile Security', () => {
+describe(`downloadFile Security`, () => {
   const mockFetch = fetch as unknown as jest.Mock;
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
@@ -20,21 +20,23 @@ describe('downloadFile Security', () => {
     jest.clearAllMocks();
   });
 
-  it('should prevent path traversal in filename', async () => {
-    const url = 'http://example.com/malicious.zip';
-    const dir = './downloads';
-    const maliciousFilename = '../../etc/passwd';
+  it(`should prevent path traversal in filename`, async () => {
+    const url = `http://example.com/malicious.zip`;
+    const dir = `./downloads`;
+    const maliciousFilename = `../../etc/passwd`;
 
     const mockResponse = {
       ok: true,
       headers: {
-        get: jest.fn().mockReturnValue(`attachment; filename=${maliciousFilename}`),
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename=${maliciousFilename}`),
       },
-      body: 'mockBody',
+      body: `mockBody`,
     };
 
     mockFetch.mockResolvedValue(mockResponse);
-    mockCreateWriteStream.mockReturnValue('mockWriteStream');
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
     mockPipeline.mockResolvedValue(undefined);
 
     await downloadFile(url, dir);

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -1,0 +1,56 @@
+import { downloadFile } from './download-file';
+import fetch from 'make-fetch-happen';
+import fs from 'fs';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+
+jest.mock('make-fetch-happen');
+jest.mock('fs');
+jest.mock('stream/promises');
+
+// We want to test path resolution, so we DON'T mock path completely
+// but we might want to spy on it if needed. For now, using actual path is better.
+
+describe('downloadFile Security', () => {
+  const mockFetch = fetch as unknown as jest.Mock;
+  const mockPipeline = pipeline as unknown as jest.Mock;
+  const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should prevent path traversal in filename', async () => {
+    const url = 'http://example.com/malicious.zip';
+    const dir = './downloads';
+    const maliciousFilename = '../../etc/passwd';
+
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest.fn().mockReturnValue(`attachment; filename=${maliciousFilename}`),
+      },
+      body: 'mockBody',
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue('mockWriteStream');
+    mockPipeline.mockResolvedValue(undefined);
+
+    await downloadFile(url, dir);
+
+    const calledPath = mockCreateWriteStream.mock.calls[0][0];
+    const resolvedDir = path.resolve(dir);
+
+    // If vulnerability is fixed, calledPath should be inside resolvedDir
+    // If not fixed, it will be outside.
+    // We assert that it MUST be inside to consider it secure.
+
+    // Check if calledPath starts with resolvedDir
+    // Note: path.resolve removes trailing slashes, so we append sep to be sure
+    const isSafe = calledPath.startsWith(resolvedDir + path.sep);
+
+    // This expectation will fail if the code is vulnerable
+    expect(isSafe).toBe(true);
+  });
+});

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,9 +14,11 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockBasename.mockImplementation((p) => p);
   });
 
   it(`should download a file successfully`, async () => {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -44,7 +44,14 @@ export async function downloadFile(
     throw new Error(`No filename in content-disposition`);
   }
 
-  const destination = path.resolve(dir, fileName);
+  const safeFileName = path.basename(fileName);
+  const destination = path.resolve(dir, safeFileName);
+  const resolvedDir = path.resolve(dir);
+
+  if (!destination.startsWith(resolvedDir)) {
+    throw new Error(`Invalid filename path: ${fileName}`);
+  }
+
   const fileStream = createWriteStream(destination);
 
   await pipeline(response.body, fileStream);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application was vulnerable to path traversal via the Content-Disposition header in src/utils/download-file.ts, allowing malicious filenames to write files outside the intended directory.
🎯 Impact: Attackers could overwrite critical system files or execute arbitrary code by manipulating the download path.
🔧 Fix: Sanitized the filename using path.basename and verified the resolved path stays within the target directory.
✅ Verification: Added src/utils/download-file.security.spec.ts which confirms the fix prevents traversal.

---
*PR created automatically by Jules for task [17945684510301931926](https://jules.google.com/task/17945684510301931926) started by @ll1r1k-1337*