### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-23 - Path Traversal in Content-Disposition
+**Vulnerability:** Path Traversal via `Content-Disposition` header in file download.
+**Learning:** The `downloadFile` utility blindly trusted the filename provided in the `Content-Disposition` header, allowing a malicious server (or MITM) to write files outside the intended download directory using path traversal sequences (e.g., `../../../etc/passwd`).
+**Prevention:** Always sanitize filenames from external sources (headers, user input) using `path.basename()` to strip directory components. Additionally, verify that the resolved path is within the intended target directory using `path.resolve()` and `.startsWith()`.

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -4,11 +4,11 @@ import fs from 'fs';
 import path from 'path';
 import { pipeline } from 'stream/promises';
 
-jest.mock('make-fetch-happen');
-jest.mock('fs');
-jest.mock('stream/promises');
+jest.mock(`make-fetch-happen`);
+jest.mock(`fs`);
+jest.mock(`stream/promises`);
 
-describe('downloadFile Security', () => {
+describe(`downloadFile Security`, () => {
   const mockFetch = fetch as unknown as jest.Mock;
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
@@ -17,44 +17,46 @@ describe('downloadFile Security', () => {
     jest.clearAllMocks();
   });
 
-  it('should sanitize path traversal in Content-Disposition filename', async () => {
-    const url = 'http://example.com/malicious.zip';
-    const dir = '/safe/download/dir';
+  it(`should sanitize path traversal in Content-Disposition filename`, async () => {
+    const url = `http://example.com/malicious.zip`;
+    const dir = `/safe/download/dir`;
     const mockResponse = {
       ok: true,
       headers: {
-        get: jest.fn().mockReturnValue('attachment; filename=../../../etc/passwd'),
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename=../../../etc/passwd`),
       },
-      body: 'malicious-payload',
+      body: `malicious-payload`,
     };
 
     mockFetch.mockResolvedValue(mockResponse);
-    mockCreateWriteStream.mockReturnValue('mockWriteStream');
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
     mockPipeline.mockResolvedValue(undefined);
 
     const result = await downloadFile(url, dir);
 
     // The filename should be sanitized to 'passwd' by path.basename
-    const expectedPath = path.resolve(dir, 'passwd');
+    const expectedPath = path.resolve(dir, `passwd`);
     expect(result).toBe(expectedPath);
 
     // Verify createWriteStream was called with the sanitized path
     expect(mockCreateWriteStream).toHaveBeenCalledWith(expectedPath);
   });
 
-  it('should throw error for invalid filename ".." which escapes directory', async () => {
-    const url = 'http://example.com/dot.zip';
-    const dir = '/safe/download/dir';
+  it(`should throw error for invalid filename ".." which escapes directory`, async () => {
+    const url = `http://example.com/dot.zip`;
+    const dir = `/safe/download/dir`;
     const mockResponse = {
       ok: true,
       headers: {
-        get: jest.fn().mockReturnValue('attachment; filename=..'),
+        get: jest.fn().mockReturnValue(`attachment; filename=..`),
       },
-      body: 'malicious-payload',
+      body: `malicious-payload`,
     };
 
     mockFetch.mockResolvedValue(mockResponse);
-    mockCreateWriteStream.mockReturnValue('mockWriteStream');
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
     mockPipeline.mockResolvedValue(undefined);
 
     // Should throw because resolving ".." escapes the directory

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -1,0 +1,63 @@
+import { downloadFile } from './download-file';
+import fetch from 'make-fetch-happen';
+import fs from 'fs';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+
+jest.mock('make-fetch-happen');
+jest.mock('fs');
+jest.mock('stream/promises');
+
+describe('downloadFile Security', () => {
+  const mockFetch = fetch as unknown as jest.Mock;
+  const mockPipeline = pipeline as unknown as jest.Mock;
+  const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should sanitize path traversal in Content-Disposition filename', async () => {
+    const url = 'http://example.com/malicious.zip';
+    const dir = '/safe/download/dir';
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest.fn().mockReturnValue('attachment; filename=../../../etc/passwd'),
+      },
+      body: 'malicious-payload',
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue('mockWriteStream');
+    mockPipeline.mockResolvedValue(undefined);
+
+    const result = await downloadFile(url, dir);
+
+    // The filename should be sanitized to 'passwd' by path.basename
+    const expectedPath = path.resolve(dir, 'passwd');
+    expect(result).toBe(expectedPath);
+
+    // Verify createWriteStream was called with the sanitized path
+    expect(mockCreateWriteStream).toHaveBeenCalledWith(expectedPath);
+  });
+
+  it('should throw error for invalid filename ".." which escapes directory', async () => {
+    const url = 'http://example.com/dot.zip';
+    const dir = '/safe/download/dir';
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest.fn().mockReturnValue('attachment; filename=..'),
+      },
+      body: 'malicious-payload',
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue('mockWriteStream');
+    mockPipeline.mockResolvedValue(undefined);
+
+    // Should throw because resolving ".." escapes the directory
+    await expect(downloadFile(url, dir)).rejects.toThrow();
+  });
+});

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,9 +14,11 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockBasename.mockReturnValue('file.zip');
   });
 
   it(`should download a file successfully`, async () => {

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -18,7 +18,7 @@ describe(`downloadFile`, () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockBasename.mockReturnValue('file.zip');
+    mockBasename.mockReturnValue(`file.zip`);
   });
 
   it(`should download a file successfully`, async () => {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -44,7 +44,13 @@ export async function downloadFile(
     throw new Error(`No filename in content-disposition`);
   }
 
-  const destination = path.resolve(dir, fileName);
+  const safeFileName = path.basename(fileName);
+  const destination = path.resolve(dir, safeFileName);
+
+  // Prevent path traversal
+  if (!destination.startsWith(path.resolve(dir))) {
+    throw new Error(`Invalid filename: ${fileName}`);
+  }
   const fileStream = createWriteStream(destination);
 
   await pipeline(response.body, fileStream);


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Content-Disposition

🚨 Severity: CRITICAL
💡 Vulnerability: The `downloadFile` utility was vulnerable to path traversal via malicious `Content-Disposition` filenames (e.g., `../../../etc/passwd`), allowing arbitrary file write outside the download directory.
🎯 Impact: An attacker (via MITM or compromised server) could overwrite critical system files during `npm install` (via postinstall script).
🔧 Fix:
- Use `path.basename()` to strip directory components from the filename.
- Verify the resolved path is within the intended target directory.
✅ Verification:
- Added `src/utils/download-file.security.spec.ts` which confirms that traversal attempts are sanitized or rejected.
- Verified existing tests pass with updated mocks.

---
*PR created automatically by Jules for task [7051622091709372816](https://jules.google.com/task/7051622091709372816) started by @ll1r1k-1337*