### PR TITLE
🛡️ Sentinel: Fix Path Traversal Vulnerability in downloadFile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - [Path Traversal in Download]
+**Vulnerability:** The `downloadFile` function blindly trusted the `Content-Disposition` header's filename parameter, allowing path traversal (Zip Slip/File Write) if the server returned a malicious filename (e.g., `../../etc/passwd`).
+**Learning:** Relying on external input (even headers from a requested URL) for file paths is dangerous. `path.resolve` does not sandbox paths.
+**Prevention:** Always sanitize filenames using `path.basename()` before using them in file system operations. Additionally, verify that the resolved path is within the intended directory using `startsWith`.

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -1,0 +1,77 @@
+import { downloadFile } from './download-file';
+import fetch from 'make-fetch-happen';
+import fs from 'fs';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+
+// Mock make-fetch-happen
+jest.mock('make-fetch-happen');
+jest.mock('stream/promises');
+
+describe('downloadFile Security', () => {
+  const mockFetch = fetch as unknown as jest.Mock;
+  const mockPipeline = pipeline as unknown as jest.Mock;
+  let createWriteStreamSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Spy on createWriteStream and prevent actual file creation
+    createWriteStreamSpy = jest.spyOn(fs, 'createWriteStream').mockImplementation(() => {
+        return {
+            on: jest.fn(),
+            write: jest.fn(),
+            end: jest.fn(),
+            emit: jest.fn(),
+        } as unknown as fs.WriteStream;
+    });
+  });
+
+  afterEach(() => {
+    createWriteStreamSpy.mockRestore();
+  });
+
+  it('should prevent path traversal attacks via Content-Disposition filename', async () => {
+    const url = 'http://example.com/malicious.zip';
+    const downloadDir = path.resolve('/tmp/nats-download');
+    // Malicious filename attempting to traverse up
+    const maliciousFilename = '../../../../etc/passwd';
+
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest.fn().mockReturnValue(`attachment; filename=${maliciousFilename}`),
+      },
+      body: 'mockBody',
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockPipeline.mockResolvedValue(undefined);
+
+    // This is expected to succeed in the vulnerable version, but write to a dangerous location
+    await downloadFile(url, downloadDir);
+
+    const callArgs = createWriteStreamSpy.mock.calls[0];
+    const destinationPath = callArgs[0] as string;
+
+    console.log('Destination Path:', destinationPath);
+
+    // Assert that the destination path is effectively outside the download directory
+    // We expect this to FAIL once we fix the vulnerability (i.e., we want it to be safe)
+    // But for now, to demonstrate the vulnerability, we verify that it IS dangerous.
+
+    // Using path.relative to see where it lands.
+    // If destinationPath resolves to /etc/passwd, and downloadDir is /tmp/nats-download
+    // relative path will be something like ../../etc/passwd
+
+    const resolvedDest = path.resolve(destinationPath);
+    const isSafe = resolvedDest.startsWith(downloadDir);
+
+    // In vulnerable code, isSafe should be FALSE.
+    // We want the test to fail if it is unsafe, so that passing the test means we are secure.
+    // So:
+    expect(isSafe).toBe(true);
+
+    // Also assert the filename is correct (sanitized)
+    expect(path.basename(destinationPath)).toBe('passwd');
+  });
+});

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -5,10 +5,10 @@ import path from 'path';
 import { pipeline } from 'stream/promises';
 
 // Mock make-fetch-happen
-jest.mock('make-fetch-happen');
-jest.mock('stream/promises');
+jest.mock(`make-fetch-happen`);
+jest.mock(`stream/promises`);
 
-describe('downloadFile Security', () => {
+describe(`downloadFile Security`, () => {
   const mockFetch = fetch as unknown as jest.Mock;
   const mockPipeline = pipeline as unknown as jest.Mock;
   let createWriteStreamSpy: jest.SpyInstance;
@@ -16,32 +16,36 @@ describe('downloadFile Security', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // Spy on createWriteStream and prevent actual file creation
-    createWriteStreamSpy = jest.spyOn(fs, 'createWriteStream').mockImplementation(() => {
+    createWriteStreamSpy = jest
+      .spyOn(fs, `createWriteStream`)
+      .mockImplementation(() => {
         return {
-            on: jest.fn(),
-            write: jest.fn(),
-            end: jest.fn(),
-            emit: jest.fn(),
+          on: jest.fn(),
+          write: jest.fn(),
+          end: jest.fn(),
+          emit: jest.fn(),
         } as unknown as fs.WriteStream;
-    });
+      });
   });
 
   afterEach(() => {
     createWriteStreamSpy.mockRestore();
   });
 
-  it('should prevent path traversal attacks via Content-Disposition filename', async () => {
-    const url = 'http://example.com/malicious.zip';
-    const downloadDir = path.resolve('/tmp/nats-download');
+  it(`should prevent path traversal attacks via Content-Disposition filename`, async () => {
+    const url = `http://example.com/malicious.zip`;
+    const downloadDir = path.resolve(`/tmp/nats-download`);
     // Malicious filename attempting to traverse up
-    const maliciousFilename = '../../../../etc/passwd';
+    const maliciousFilename = `../../../../etc/passwd`;
 
     const mockResponse = {
       ok: true,
       headers: {
-        get: jest.fn().mockReturnValue(`attachment; filename=${maliciousFilename}`),
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename=${maliciousFilename}`),
       },
-      body: 'mockBody',
+      body: `mockBody`,
     };
 
     mockFetch.mockResolvedValue(mockResponse);
@@ -53,7 +57,7 @@ describe('downloadFile Security', () => {
     const callArgs = createWriteStreamSpy.mock.calls[0];
     const destinationPath = callArgs[0] as string;
 
-    console.log('Destination Path:', destinationPath);
+    console.log(`Destination Path:`, destinationPath);
 
     // Assert that the destination path is effectively outside the download directory
     // We expect this to FAIL once we fix the vulnerability (i.e., we want it to be safe)
@@ -72,6 +76,6 @@ describe('downloadFile Security', () => {
     expect(isSafe).toBe(true);
 
     // Also assert the filename is correct (sanitized)
-    expect(path.basename(destinationPath)).toBe('passwd');
+    expect(path.basename(destinationPath)).toBe(`passwd`);
   });
 });

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,9 +14,11 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockBasename.mockImplementation((name) => name);
   });
 
   it(`should download a file successfully`, async () => {
@@ -41,6 +43,7 @@ describe(`downloadFile`, () => {
     expect(result).toBe(destination);
     expect(mockFetch).toHaveBeenCalledWith(url, {});
     expect(mockResolve).toHaveBeenCalledWith(dir, `file.zip`);
+    expect(mockResolve).toHaveBeenCalledWith(dir);
     expect(mockCreateWriteStream).toHaveBeenCalledWith(destination);
     expect(mockPipeline).toHaveBeenCalledWith(`mockBody`, `mockWriteStream`);
   });

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -44,7 +44,16 @@ export async function downloadFile(
     throw new Error(`No filename in content-disposition`);
   }
 
-  const destination = path.resolve(dir, fileName);
+  // Sanitize the filename to prevent path traversal
+  const safeFileName = path.basename(fileName);
+  const destination = path.resolve(dir, safeFileName);
+
+  // Ensure the resolved path is within the intended directory
+  const resolvedDir = path.resolve(dir);
+  if (!destination.startsWith(resolvedDir)) {
+    throw new Error(`Invalid file path: ${destination}`);
+  }
+
   const fileStream = createWriteStream(destination);
 
   await pipeline(response.body, fileStream);


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix Path Traversal Vulnerability

🚨 Severity: CRITICAL
💡 Vulnerability: The `downloadFile` function in `src/utils/download-file.ts` blindly trusted the filename provided in the `Content-Disposition` header from the remote server. This allowed a malicious server (or Man-in-the-Middle) to specify a filename like `../../etc/passwd`, causing the file to be written outside the intended directory.
🎯 Impact: Arbitrary file write. An attacker could overwrite critical system files or inject malicious code into the application directory.
🔧 Fix:
- Sanitized the filename using `path.basename()` to strip any directory components.
- Added a check to ensure the resolved destination path starts with the resolved target directory path.
✅ Verification:
- Added a new security test `src/utils/download-file.security.spec.ts` that mocks a malicious server response and asserts that the file is written to the correct, sanitized location (`/tmp/nats-download/passwd` instead of `/etc/passwd`).
- Ran existing tests (`npm test`) to ensure no regressions. The download logic was also verified by running the `postinstall` script which successfully downloaded the NATS binary.

---
*PR created automatically by Jules for task [381117425117143503](https://jules.google.com/task/381117425117143503) started by @ll1r1k-1337*