### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-19 - Path Traversal in File Download
+**Vulnerability:** The `downloadFile` function used the `Content-Disposition` filename directly in `path.resolve` without sanitization. This allowed path traversal (Zip Slip) attacks if the server provided a malicious filename like `../../evil.txt`.
+**Learning:** `Content-Disposition` filenames are untrusted user input and must be sanitized. `path.resolve` is vulnerable when combined with unsanitized relative paths.
+**Prevention:** Always use `path.basename()` on filenames from external sources before using them in file system operations. Explicitly verify the resolved path is within the target directory using `.startsWith()`.

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -3,49 +3,49 @@ import { downloadFile } from './download-file';
 import fetch from 'make-fetch-happen';
 
 // Mock make-fetch-happen
-jest.mock('make-fetch-happen');
+jest.mock(`make-fetch-happen`);
 const mockFetch = fetch as unknown as jest.Mock;
 
 // Mock fs partially
 const mockCreateWriteStream = jest.fn();
-jest.mock('fs', () => {
-  const actualFs = jest.requireActual('fs');
+jest.mock(`fs`, () => {
+  const actualFs = jest.requireActual(`fs`);
   return {
     ...actualFs,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     createWriteStream: (path: any) => mockCreateWriteStream(path),
   };
 });
 
 // Mock pipeline
-jest.mock('stream/promises', () => ({
+jest.mock(`stream/promises`, () => ({
   pipeline: jest.fn().mockResolvedValue(undefined),
 }));
 
-
-describe('downloadFile Security Check', () => {
+describe(`downloadFile Security Check`, () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('should sanitize filename to prevent path traversal via Content-Disposition', async () => {
-    const maliciousFilename = '../../../../tmp/hacked.txt';
-    const targetDir = path.resolve('/safe/dir');
+  it(`should sanitize filename to prevent path traversal via Content-Disposition`, async () => {
+    const maliciousFilename = `../../../../tmp/hacked.txt`;
+    const targetDir = path.resolve(`/safe/dir`);
 
     mockFetch.mockResolvedValue({
       ok: true,
       headers: {
         get: (key: string) => {
-          if (key.toLowerCase() === 'content-disposition') {
+          if (key.toLowerCase() === `content-disposition`) {
             return `attachment; filename=${maliciousFilename}`;
           }
           return null;
-        }
+        },
       },
-      body: 'mock-body'
+      body: `mock-body`,
     });
 
     try {
-      await downloadFile('http://example.com/file', targetDir);
+      await downloadFile(`http://example.com/file`, targetDir);
     } catch (e) {
       console.error(e);
     }
@@ -63,30 +63,30 @@ describe('downloadFile Security Check', () => {
     expect(writePath.startsWith(targetDir)).toBe(true);
   });
 
-  it('should handle quoted filenames correctly', async () => {
-    const quotedFilename = '"safe-file.txt"';
-    const targetDir = path.resolve('/safe/dir');
+  it(`should handle quoted filenames correctly`, async () => {
+    const quotedFilename = `"safe-file.txt"`;
+    const targetDir = path.resolve(`/safe/dir`);
 
     mockFetch.mockResolvedValue({
       ok: true,
       headers: {
         get: (key: string) => {
-          if (key.toLowerCase() === 'content-disposition') {
+          if (key.toLowerCase() === `content-disposition`) {
             return `attachment; filename=${quotedFilename}`;
           }
           return null;
-        }
+        },
       },
-      body: 'mock-body'
+      body: `mock-body`,
     });
 
-    await downloadFile('http://example.com/file', targetDir);
+    await downloadFile(`http://example.com/file`, targetDir);
 
     const calls = mockCreateWriteStream.mock.calls;
     expect(calls.length).toBeGreaterThan(0);
     const writePath = calls[0][0];
 
-    const expectedSafePath = path.resolve(targetDir, 'safe-file.txt');
+    const expectedSafePath = path.resolve(targetDir, `safe-file.txt`);
     expect(writePath).toBe(expectedSafePath);
   });
 });

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -1,0 +1,92 @@
+import path from 'path';
+import { downloadFile } from './download-file';
+import fetch from 'make-fetch-happen';
+
+// Mock make-fetch-happen
+jest.mock('make-fetch-happen');
+const mockFetch = fetch as unknown as jest.Mock;
+
+// Mock fs partially
+const mockCreateWriteStream = jest.fn();
+jest.mock('fs', () => {
+  const actualFs = jest.requireActual('fs');
+  return {
+    ...actualFs,
+    createWriteStream: (path: any) => mockCreateWriteStream(path),
+  };
+});
+
+// Mock pipeline
+jest.mock('stream/promises', () => ({
+  pipeline: jest.fn().mockResolvedValue(undefined),
+}));
+
+
+describe('downloadFile Security Check', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should sanitize filename to prevent path traversal via Content-Disposition', async () => {
+    const maliciousFilename = '../../../../tmp/hacked.txt';
+    const targetDir = path.resolve('/safe/dir');
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      headers: {
+        get: (key: string) => {
+          if (key.toLowerCase() === 'content-disposition') {
+            return `attachment; filename=${maliciousFilename}`;
+          }
+          return null;
+        }
+      },
+      body: 'mock-body'
+    });
+
+    try {
+      await downloadFile('http://example.com/file', targetDir);
+    } catch (e) {
+      console.error(e);
+    }
+
+    // Check what path createWriteStream was called with
+    const calls = mockCreateWriteStream.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const writePath = calls[0][0];
+
+    // Verify fix: the path should be sanitized and inside targetDir
+    const safeFilename = path.basename(maliciousFilename);
+    const expectedSafePath = path.resolve(targetDir, safeFilename);
+
+    expect(writePath).toBe(expectedSafePath);
+    expect(writePath.startsWith(targetDir)).toBe(true);
+  });
+
+  it('should handle quoted filenames correctly', async () => {
+    const quotedFilename = '"safe-file.txt"';
+    const targetDir = path.resolve('/safe/dir');
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      headers: {
+        get: (key: string) => {
+          if (key.toLowerCase() === 'content-disposition') {
+            return `attachment; filename=${quotedFilename}`;
+          }
+          return null;
+        }
+      },
+      body: 'mock-body'
+    });
+
+    await downloadFile('http://example.com/file', targetDir);
+
+    const calls = mockCreateWriteStream.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const writePath = calls[0][0];
+
+    const expectedSafePath = path.resolve(targetDir, 'safe-file.txt');
+    expect(writePath).toBe(expectedSafePath);
+  });
+});

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -20,12 +20,14 @@ describe(`downloadFile`, () => {
     jest.clearAllMocks();
     mockBasename.mockImplementation((p) => p);
     // Default resolve implementation to handle dir check
-    mockResolve.mockImplementation((...args) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockResolve.mockImplementation((...args: any[]) => {
       // If resolving just one arg, assume it's dir resolution
       if (args.length === 1) return args[0];
       // If resolving two args, assume it's dir + file
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       if (args.length === 2) return `${args[0]}/${args[1]}`;
-      return '/tmp/file.zip';
+      return `/tmp/file.zip`;
     });
   });
 

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,9 +14,19 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockBasename.mockImplementation((p) => p);
+    // Default resolve implementation to handle dir check
+    mockResolve.mockImplementation((...args) => {
+      // If resolving just one arg, assume it's dir resolution
+      if (args.length === 1) return args[0];
+      // If resolving two args, assume it's dir + file
+      if (args.length === 2) return `${args[0]}/${args[1]}`;
+      return '/tmp/file.zip';
+    });
   });
 
   it(`should download a file successfully`, async () => {
@@ -32,7 +42,6 @@ describe(`downloadFile`, () => {
     };
 
     mockFetch.mockResolvedValue(mockResponse);
-    mockResolve.mockReturnValue(destination);
     mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
     mockPipeline.mockResolvedValue(undefined);
 
@@ -40,6 +49,7 @@ describe(`downloadFile`, () => {
 
     expect(result).toBe(destination);
     expect(mockFetch).toHaveBeenCalledWith(url, {});
+    expect(mockBasename).toHaveBeenCalledWith(`file.zip`);
     expect(mockResolve).toHaveBeenCalledWith(dir, `file.zip`);
     expect(mockCreateWriteStream).toHaveBeenCalledWith(destination);
     expect(mockPipeline).toHaveBeenCalledWith(`mockBody`, `mockWriteStream`);

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -39,10 +39,10 @@ export async function downloadFile(
   const contentDisposition = response.headers.get(CONTENT_DISPOSITION_KEY);
   let fileName: string | undefined;
 
-  if (contentDisposition) {
+  if (contentDisposition != null) {
     // Try to extract filename using regex for quoted and unquoted values
     const match = contentDisposition.match(/filename="?([^"]+)"?/);
-    if (match) {
+    if (match != null) {
       fileName = match[1];
     } else {
       // Fallback to simple split if regex doesn't match
@@ -62,7 +62,7 @@ export async function downloadFile(
   // Ensure the resolved path is within the target directory
   const resolvedDir = path.resolve(dir);
   if (!destination.startsWith(resolvedDir)) {
-     throw new Error(`Invalid destination path: ${destination}`);
+    throw new Error(`Invalid destination path: ${destination}`);
   }
 
   const fileStream = createWriteStream(destination);

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,15 +36,35 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
-    .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+  const contentDisposition = response.headers.get(CONTENT_DISPOSITION_KEY);
+  let fileName: string | undefined;
+
+  if (contentDisposition) {
+    // Try to extract filename using regex for quoted and unquoted values
+    const match = contentDisposition.match(/filename="?([^"]+)"?/);
+    if (match) {
+      fileName = match[1];
+    } else {
+      // Fallback to simple split if regex doesn't match
+      fileName = contentDisposition.split(`filename=`)?.[1];
+    }
+  }
 
   if (fileName == null) {
     throw new Error(`No filename in content-disposition`);
   }
 
+  // Sanitize filename to prevent path traversal
+  fileName = path.basename(fileName);
+
   const destination = path.resolve(dir, fileName);
+
+  // Ensure the resolved path is within the target directory
+  const resolvedDir = path.resolve(dir);
+  if (!destination.startsWith(resolvedDir)) {
+     throw new Error(`Invalid destination path: ${destination}`);
+  }
+
   const fileStream = createWriteStream(destination);
 
   await pipeline(response.body, fileStream);


### PR DESCRIPTION
This PR addresses a critical security vulnerability where the `downloadFile` function was susceptible to Path Traversal (Zip Slip) attacks. The fix involves sanitizing the filename extracted from the `Content-Disposition` header using `path.basename()`, ensuring that files can only be written to the intended directory. Additionally, the parsing logic for `Content-Disposition` has been improved to correctly handle quoted filenames.

Verification:
- A new security test file `src/utils/download-file.security.spec.ts` has been added to verify that malicious filenames like `../../evil.txt` are sanitized to `evil.txt` within the target directory.
- Existing tests in `src/utils/download-file.spec.ts` have been updated to accommodate the new security check and continue to pass.


---
*PR created automatically by Jules for task [631948523230686233](https://jules.google.com/task/631948523230686233) started by @ll1r1k-1337*