### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in downloadFile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel's Journal
+
+## 2026-02-20 - Path Traversal in File Downloads
+**Vulnerability:** The `downloadFile` utility blindly trusted the `filename` parameter from the `Content-Disposition` header, allowing path traversal (e.g., `../../etc/passwd`).
+**Learning:** External inputs like HTTP headers (specifically `Content-Disposition`) must be treated as untrusted and sanitized before being used in file system operations.
+**Prevention:** Always sanitize filenames derived from external sources using `path.basename()` to strip directory components, ensuring the file is written only to the intended directory.

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -1,0 +1,49 @@
+import { downloadFile } from './download-file';
+import fetch from 'make-fetch-happen';
+import fs from 'fs';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+
+jest.mock(`make-fetch-happen`);
+jest.mock(`fs`);
+jest.mock(`stream/promises`);
+
+describe(`downloadFile Security`, () => {
+  const mockFetch = fetch as unknown as jest.Mock;
+  const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
+  const mockPipeline = pipeline as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`should sanitize filename to prevent path traversal`, async () => {
+    const url = `http://example.com/evil.zip`;
+    const safeDir = path.resolve(`/safe/dir`);
+    const evilFilename = `../../evil.txt`;
+    const safeFilename = `evil.txt`;
+
+    // The expected safe path
+    const expectedSafePath = path.resolve(safeDir, safeFilename);
+
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest.fn().mockReturnValue(`attachment; filename=${evilFilename}`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    const result = await downloadFile(url, safeDir);
+
+    expect(result).toBe(expectedSafePath);
+    expect(mockCreateWriteStream).toHaveBeenCalledWith(expectedSafePath);
+
+    // Verify that the path is inside the safe directory
+    expect(result.startsWith(safeDir)).toBe(true);
+  });
+});

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,9 +14,11 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockBasename.mockImplementation((name) => name);
   });
 
   it(`should download a file successfully`, async () => {
@@ -40,6 +42,7 @@ describe(`downloadFile`, () => {
 
     expect(result).toBe(destination);
     expect(mockFetch).toHaveBeenCalledWith(url, {});
+    expect(mockBasename).toHaveBeenCalledWith(`file.zip`);
     expect(mockResolve).toHaveBeenCalledWith(dir, `file.zip`);
     expect(mockCreateWriteStream).toHaveBeenCalledWith(destination);
     expect(mockPipeline).toHaveBeenCalledWith(`mockBody`, `mockWriteStream`);

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,15 +36,16 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
-    .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+  const contentDisposition = response.headers.get(CONTENT_DISPOSITION_KEY);
+  const fileName = contentDisposition?.split(`filename=`)?.[1];
 
   if (fileName == null) {
     throw new Error(`No filename in content-disposition`);
   }
 
-  const destination = path.resolve(dir, fileName);
+  // Prevent path traversal
+  const safeFileName = path.basename(fileName);
+  const destination = path.resolve(dir, safeFileName);
   const fileStream = createWriteStream(destination);
 
   await pipeline(response.body, fileStream);


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in downloadFile

🚨 Severity: CRITICAL
💡 Vulnerability: The `downloadFile` utility was vulnerable to Path Traversal (Zip Slip) attacks because it blindly trusted the filename from the `Content-Disposition` header. A malicious server could supply a filename like `../../etc/passwd` to overwrite files outside the intended download directory.
🎯 Impact: Arbitrary file write, potential remote code execution or system compromise if critical files are overwritten.
🔧 Fix: Implemented `path.basename()` to sanitize the filename, stripping all directory components and ensuring the file is written only to the target directory.
✅ Verification:
- Added `src/utils/download-file.security.spec.ts` which reproduces the vulnerability and verifies the fix.
- Updated `src/utils/download-file.spec.ts` to mock `path.basename`.
- Verified no regressions with full test suite.
- Added journal entry in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [14733139063211119701](https://jules.google.com/task/14733139063211119701) started by @ll1r1k-1337*