### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in file download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-21 - [CRITICAL] Path Traversal in File Download
+**Vulnerability:** The `downloadFile` function extracted the filename directly from the `Content-Disposition` header without sanitization, allowing a malicious server to overwrite files outside the intended directory via directory traversal characters (e.g., `../../etc/passwd`).
+**Learning:** `path.resolve` does not sanitize paths; it resolves them. Trusting external input (even headers) for file paths is dangerous.
+**Prevention:** Always use `path.basename()` on filenames extracted from external sources before using them in file system operations.

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -1,0 +1,79 @@
+import { downloadFile } from './download-file';
+import fetch from 'make-fetch-happen';
+import path from 'path';
+import fs from 'fs';
+import { pipeline } from 'stream/promises';
+
+jest.mock(`make-fetch-happen`);
+jest.mock(`fs`);
+jest.mock(`stream/promises`);
+
+describe(`downloadFile security`, () => {
+  const mockFetch = fetch as unknown as jest.Mock;
+  const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
+  const mockPipeline = pipeline as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`should prevent path traversal in filename`, async () => {
+    const url = `http://example.com/malicious.zip`;
+    const dir = `/tmp`;
+    // The vulnerability allows this filename to be resolved outside of dir
+    const maliciousFilename = `../../../../etc/passwd`;
+
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename=${maliciousFilename}`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    // We expect the current implementation to resolve to the malicious path
+    // The fix should make this throw an error or sanitize the path
+    const resolvedPath = await downloadFile(url, dir);
+
+    // Check if path traversal occurred
+    // If resolvedPath is effectively '/etc/passwd' (or relative equivalent), it's vulnerable.
+    // path.resolve('/tmp', '../../../../etc/passwd') -> '/etc/passwd' (on POSIX)
+
+    const expectedSafePath = path.resolve(
+      dir,
+      path.basename(maliciousFilename),
+    );
+    expect(resolvedPath).toBe(expectedSafePath);
+
+    // Check that it IS contained in the intended directory
+    expect(resolvedPath.startsWith(path.resolve(dir))).toBe(true);
+  });
+
+  it(`should handle normal filenames correctly`, async () => {
+    const url = `http://example.com/file.zip`;
+    const dir = `/tmp`;
+    const filename = `file.zip`;
+
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest.fn().mockReturnValue(`attachment; filename=${filename}`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    const resolvedPath = await downloadFile(url, dir);
+
+    expect(resolvedPath).toBe(path.resolve(dir, filename));
+  });
+});

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,9 +14,11 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockBasename.mockImplementation((f) => f);
   });
 
   it(`should download a file successfully`, async () => {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -44,7 +44,7 @@ export async function downloadFile(
     throw new Error(`No filename in content-disposition`);
   }
 
-  const destination = path.resolve(dir, fileName);
+  const destination = path.resolve(dir, path.basename(fileName));
   const fileStream = createWriteStream(destination);
 
   await pipeline(response.body, fileStream);


### PR DESCRIPTION
This PR addresses a critical Path Traversal vulnerability in the `downloadFile` utility.

Changes:
- Modified `src/utils/download-file.ts` to sanitize the filename using `path.basename()`.
- Updated `src/utils/download-file.spec.ts` to mock `path.basename`.
- Added `src/utils/download-file.security.spec.ts` to test and verify the fix against path traversal attacks.
- Added journal entry in `.jules/sentinel.md`.

Verification:
- Run `npm test` to verify all tests pass, including the new security test.

---
*PR created automatically by Jules for task [15316512341330094044](https://jules.google.com/task/15316512341330094044) started by @ll1r1k-1337*