### PR TITLE
⚡ Bolt: Optimize NATS server ready check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-02-21 - Optimize stderr monitoring
+**Learning:** For high-volume log streams (like `stderr` in `NatsServer`), using `Buffer.includes()` on binary chunks to detect state changes (e.g., "Server is ready") is significantly more efficient than calling `.toString()` on every chunk.
+**Action:** When monitoring subprocess output for a specific string, use `Buffer.includes` on raw chunks and maintain a state flag to stop processing once the target state is reached.

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -5,6 +5,9 @@ import {
   getProjectPath,
   type NatsMemoryServerConfig,
 } from './utils';
+
+const SERVER_READY_BUFFER = Buffer.from(`Server is ready`);
+
 export interface Logger {
   log: (message: string, ...args: unknown[]) => void;
   error: (message: string, ...args: unknown[]) => void;
@@ -59,6 +62,7 @@ export class NatsServer {
 
     const config = { ...projectConfig, ...this.options };
     const { args, ip, port = await getFreePort(), binPath } = config;
+    let isReady = false;
 
     return await new Promise((resolve, reject) => {
       this.process = child_process.spawn(
@@ -79,19 +83,53 @@ export class NatsServer {
       });
 
       this.process.stderr.on(`data`, (data: unknown) => {
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        const dataStr = data?.toString();
-
-        if (verbose && dataStr != null) {
-          logger.log(dataStr);
+        // Optimization: If the server is already ready and we're not in verbose mode,
+        // we can skip processing the stderr output entirely to save resources.
+        if (isReady && !verbose) {
+          return;
         }
 
-        if (dataStr?.includes(`Server is ready`) === true) {
-          if (verbose) {
-            logger.log(`NATS server is ready!`);
+        const isBuffer = Buffer.isBuffer(data);
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
+        let dataStr = isBuffer ? undefined : data?.toString();
+
+        if (verbose) {
+          if (dataStr === undefined) {
+            // eslint-disable-next-line @typescript-eslint/no-base-to-string
+            dataStr = data?.toString();
           }
-          resolve(this);
-          this.process?.unref();
+
+          if (dataStr != null) {
+            logger.log(dataStr);
+          }
+        }
+
+        if (!isReady) {
+          let ready = false;
+
+          if (isBuffer) {
+            if (data.includes(SERVER_READY_BUFFER)) {
+              ready = true;
+            }
+          } else {
+            if (dataStr === undefined) {
+              // eslint-disable-next-line @typescript-eslint/no-base-to-string
+              dataStr = data?.toString();
+            }
+
+            if (dataStr?.includes(`Server is ready`) === true) {
+              ready = true;
+            }
+          }
+
+          if (ready) {
+            isReady = true;
+            if (verbose) {
+              logger.log(`NATS server is ready!`);
+            }
+            resolve(this);
+            this.process?.unref();
+          }
         }
       });
 


### PR DESCRIPTION
💡 What: Optimized the NATS server readiness check in `src/nats-server.ts`.
🎯 Why: The previous implementation converted every stderr chunk to a string and checked for "Server is ready", even after the server was already running. This caused unnecessary CPU and memory overhead.
📊 Impact:
- Zero overhead on stderr processing after server startup (when verbose logging is off).
- Reduced string allocations during startup by using `Buffer.includes`.
🔬 Measurement: Verified with `npm test`. The logic correctly detects server readiness and respects verbose logging settings.

---
*PR created automatically by Jules for task [13595791296539827113](https://jules.google.com/task/13595791296539827113) started by @ll1r1k-1337*