### PR TITLE
⚡ Bolt: Optimize NATS server startup check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-02-22 - [Optimizing Stream Processing]
+**Learning:** Checking binary buffers directly with `Buffer.includes()` is much faster than `toString().includes()` for finding sentinel values in high-throughput streams.
+**Action:** When monitoring `stderr` or `stdout` for a specific message, pre-allocate the message as a Buffer and use `includes()` on the raw chunks.

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -5,6 +5,9 @@ import {
   getProjectPath,
   type NatsMemoryServerConfig,
 } from './utils';
+
+const serverReadyBuffer = Buffer.from('Server is ready');
+
 export interface Logger {
   log: (message: string, ...args: unknown[]) => void;
   error: (message: string, ...args: unknown[]) => void;
@@ -61,6 +64,8 @@ export class NatsServer {
     const { args, ip, port = await getFreePort(), binPath } = config;
 
     return await new Promise((resolve, reject) => {
+      let isReady = false;
+
       this.process = child_process.spawn(
         binPath,
         [`--addr`, ip, `--port`, port.toString(), ...args],
@@ -78,18 +83,23 @@ export class NatsServer {
         reject(err);
       });
 
-      this.process.stderr.on(`data`, (data: unknown) => {
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        const dataStr = data?.toString();
-
-        if (verbose && dataStr != null) {
-          logger.log(dataStr);
+      this.process.stderr.on(`data`, (data: Buffer) => {
+        // Optimization: if server is ready and not verbose, skip processing to avoid string allocation
+        if (isReady && !verbose) {
+          return;
         }
 
-        if (dataStr?.includes(`Server is ready`) === true) {
+        if (verbose) {
+          logger.log(data.toString());
+        }
+
+        if (!isReady && data.includes(serverReadyBuffer)) {
+          isReady = true;
+
           if (verbose) {
             logger.log(`NATS server is ready!`);
           }
+
           resolve(this);
           this.process?.unref();
         }

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -6,7 +6,7 @@ import {
   type NatsMemoryServerConfig,
 } from './utils';
 
-const serverReadyBuffer = Buffer.from('Server is ready');
+const serverReadyBuffer = Buffer.from(`Server is ready`);
 
 export interface Logger {
   log: (message: string, ...args: unknown[]) => void;


### PR DESCRIPTION
⚡ Bolt: Optimize NATS server startup check

💡 What:
Replaced `data.toString().includes('Server is ready')` with `data.includes(serverReadyBuffer)` in the stderr listener.
Added an `isReady` flag to skip processing stderr chunks once the server is ready (when not verbose).

🎯 Why:
The previous implementation converted every stderr chunk to a string and searched it, even after the server had started. This wasted CPU cycles and memory allocations, especially for high-volume logs.

📊 Impact:
- Reduces memory allocations during startup and runtime.
- Avoids unnecessary string conversions.
- Stops processing stderr entirely (when not verbose) after startup.

🔬 Measurement:
Run `npm test` and observe that the server starts correctly. Verify `verbose: false` behavior still works (server starts but logs are suppressed).

---
*PR created automatically by Jules for task [17365301789014912653](https://jules.google.com/task/17365301789014912653) started by @ll1r1k-1337*