### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in file download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-28 - Path Traversal in File Download
+**Vulnerability:** Path traversal in `downloadFile` function when processing `Content-Disposition` header.
+**Learning:** `make-fetch-happen` (and `fetch`) does not automatically sanitize filenames from headers. Using `path.resolve` directly with unsanitized input is unsafe.
+**Prevention:** Always use `path.basename()` on filenames from external sources before using them in file system operations.

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -1,0 +1,49 @@
+import { downloadFile } from './download-file';
+import fetch from 'make-fetch-happen';
+import fs from 'fs';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+
+jest.mock(`make-fetch-happen`);
+jest.mock(`fs`);
+jest.mock(`stream/promises`);
+
+describe(`downloadFile security`, () => {
+  const mockFetch = fetch as unknown as jest.Mock;
+  const mockPipeline = pipeline as unknown as jest.Mock;
+  const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`should prevent path traversal by sanitizing filename`, async () => {
+    const url = `http://example.com/evil.zip`;
+    const dir = `/safe/downloads`;
+    const maliciousFilename = `../../../../tmp/evil.exe`;
+
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename=${maliciousFilename}`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    const result = await downloadFile(url, dir);
+
+    // The result should now be inside dir, with just the basename of the malicious filename
+    const expectedFilename = path.basename(maliciousFilename);
+    const expectedPath = path.resolve(dir, expectedFilename);
+
+    expect(result).toBe(expectedPath);
+    expect(result.startsWith(dir)).toBe(true);
+    expect(mockCreateWriteStream).toHaveBeenCalledWith(expectedPath);
+  });
+});

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,9 +14,11 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockBasename.mockImplementation((name) => name);
   });
 
   it(`should download a file successfully`, async () => {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -44,7 +44,7 @@ export async function downloadFile(
     throw new Error(`No filename in content-disposition`);
   }
 
-  const destination = path.resolve(dir, fileName);
+  const destination = path.resolve(dir, path.basename(fileName));
   const fileStream = createWriteStream(destination);
 
   await pipeline(response.body, fileStream);


### PR DESCRIPTION
This PR fixes a critical path traversal vulnerability in the `downloadFile` function. Previously, the filename from the `Content-Disposition` header was used directly in `path.resolve`, allowing malicious servers to overwrite files outside the download directory.

The fix uses `path.basename()` to sanitize the filename, ensuring that only the filename component is used.

A new security test file `src/utils/download-file.security.spec.ts` has been added to prevent regression. The existing tests in `src/utils/download-file.spec.ts` have been updated to accommodate the use of `path.basename`.

Verification:
- Run `npm test src/utils/download-file.security.spec.ts` to verify the fix.
- Run `npm test` to verify no regressions in other tests.


---
*PR created automatically by Jules for task [470863693358056734](https://jules.google.com/task/470863693358056734) started by @ll1r1k-1337*