### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix path traversal in file download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-23 - Path Traversal in File Download
+**Vulnerability:** Found a path traversal vulnerability in `src/utils/download-file.ts` where `Content-Disposition` filenames were used directly in `path.resolve()`, allowing attackers to write files outside the intended directory.
+**Learning:** `path.resolve()` does not sanitize paths; it resolves relative paths. Trusting external filenames (even from headers) is dangerous without sanitization.
+**Prevention:** Always use `path.basename()` on filenames derived from external sources before joining them to a directory path.

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -1,0 +1,52 @@
+import { downloadFile } from './download-file';
+import fetch from 'make-fetch-happen';
+import fs from 'fs';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+
+// Mock make-fetch-happen and fs, but NOT path
+jest.mock(`make-fetch-happen`);
+jest.mock(`fs`);
+jest.mock(`stream/promises`);
+
+describe(`downloadFile Security`, () => {
+  const mockFetch = fetch as unknown as jest.Mock;
+  const mockPipeline = pipeline as unknown as jest.Mock;
+  const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`should prevent path traversal in Content-Disposition filename`, async () => {
+    const url = `http://example.com/malicious.zip`;
+    const dir = `/tmp/downloads`;
+    // Malicious filename attempting to traverse up
+    const maliciousFilename = `../../etc/passwd`;
+
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename=${maliciousFilename}`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    await downloadFile(url, dir);
+
+    const callArgs = mockCreateWriteStream.mock.calls[0];
+    const destinationPath = callArgs[0];
+
+    // We expect the function to strip the path traversal and just use the filename
+    // So "passwd" instead of "../../etc/passwd"
+    const expectedPath = path.resolve(dir, `passwd`);
+
+    expect(destinationPath).toBe(expectedPath);
+  });
+});

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,9 +14,11 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockBasename.mockImplementation((f) => f);
   });
 
   it(`should download a file successfully`, async () => {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -44,7 +44,7 @@ export async function downloadFile(
     throw new Error(`No filename in content-disposition`);
   }
 
-  const destination = path.resolve(dir, fileName);
+  const destination = path.resolve(dir, path.basename(fileName));
   const fileStream = createWriteStream(destination);
 
   await pipeline(response.body, fileStream);


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix path traversal in file download

🚨 Severity: CRITICAL
💡 Vulnerability: The `downloadFile` utility was vulnerable to path traversal (Zip Slip) because it used the `filename` from the `Content-Disposition` header directly in `path.resolve()`. This could allow a malicious server (or compromised URL) to write files outside the intended download directory.
🎯 Impact: An attacker could overwrite critical system files or execute arbitrary code by overwriting configuration files or binaries.
🔧 Fix: Implemented `path.basename()` to sanitize the filename before resolving the destination path. This ensures that any directory traversal characters (e.g., `../`) are stripped.
✅ Verification: Added a security test case in `src/utils/download-file.security.spec.ts` that attempts a path traversal and asserts that the file is written to the sanitized location.

---
*PR created automatically by Jules for task [13822294221552113782](https://jules.google.com/task/13822294221552113782) started by @ll1r1k-1337*