### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-25 - Path Traversal in File Downloads
+**Vulnerability:** Unsanitized `Content-Disposition` filenames allowed writing files outside the target directory (Path Traversal/Zip Slip).
+**Learning:** File downloads relying on external headers (`Content-Disposition`) must treat filenames as untrusted input.
+**Prevention:** Use `path.basename()` to strip directory components from filenames derived from external sources before using them in file system operations.

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -1,0 +1,54 @@
+import { downloadFile } from './download-file';
+import fetch from 'make-fetch-happen';
+import fs from 'fs';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+
+jest.mock(`make-fetch-happen`);
+jest.mock(`fs`, () => {
+  const originalFs = jest.requireActual(`fs`);
+  return {
+    ...originalFs,
+    createWriteStream: jest.fn(),
+  };
+});
+jest.mock(`stream/promises`);
+
+describe(`downloadFile Security`, () => {
+  const mockFetch = fetch as unknown as jest.Mock;
+  const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
+  const mockPipeline = pipeline as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`should prevent path traversal in Content-Disposition header`, async () => {
+    const url = `http://example.com/malicious.zip`;
+    const dir = `/tmp/safe-dir`;
+    const maliciousFilename = `../../../../etc/passwd`;
+
+    // Unquoted filename triggers direct path traversal
+    const headerValue = `attachment; filename=${maliciousFilename}`;
+
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest.fn().mockReturnValue(headerValue),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockPipeline.mockResolvedValue(undefined);
+
+    await downloadFile(url, dir);
+
+    const writtenPath = mockCreateWriteStream.mock.calls[0][0];
+
+    // Expect the path to be sanitized to just 'passwd' inside the dir
+    // This assertion should FAIL before the fix
+    const safePath = path.resolve(dir, `passwd`);
+    expect(writtenPath).toBe(safePath);
+  });
+});

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,6 +14,7 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -33,6 +34,7 @@ describe(`downloadFile`, () => {
 
     mockFetch.mockResolvedValue(mockResponse);
     mockResolve.mockReturnValue(destination);
+    mockBasename.mockReturnValue(`file.zip`);
     mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
     mockPipeline.mockResolvedValue(undefined);
 
@@ -40,6 +42,7 @@ describe(`downloadFile`, () => {
 
     expect(result).toBe(destination);
     expect(mockFetch).toHaveBeenCalledWith(url, {});
+    expect(mockBasename).toHaveBeenCalledWith(`file.zip`);
     expect(mockResolve).toHaveBeenCalledWith(dir, `file.zip`);
     expect(mockCreateWriteStream).toHaveBeenCalledWith(destination);
     expect(mockPipeline).toHaveBeenCalledWith(`mockBody`, `mockWriteStream`);
@@ -58,6 +61,7 @@ describe(`downloadFile`, () => {
 
     mockFetch.mockResolvedValue(mockResponse);
     mockResolve.mockReturnValue(`/tmp/file.zip`);
+    mockBasename.mockReturnValue(`file.zip`);
     mockPipeline.mockResolvedValue(undefined);
 
     await downloadFile(url, `/tmp`, { httpProxy: proxy });
@@ -78,6 +82,7 @@ describe(`downloadFile`, () => {
 
     mockFetch.mockResolvedValue(mockResponse);
     mockResolve.mockReturnValue(`/tmp/file.zip`);
+    mockBasename.mockReturnValue(`file.zip`);
     mockPipeline.mockResolvedValue(undefined);
 
     await downloadFile(url, `/tmp`, { httpsProxy: proxy });
@@ -98,6 +103,7 @@ describe(`downloadFile`, () => {
 
     mockFetch.mockResolvedValue(mockResponse);
     mockResolve.mockReturnValue(`/tmp/file.zip`);
+    mockBasename.mockReturnValue(`file.zip`);
     mockPipeline.mockResolvedValue(undefined);
 
     await downloadFile(url, `/tmp`, { noProxy });

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,13 +36,23 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
-    .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+  const contentDisposition = response.headers.get(CONTENT_DISPOSITION_KEY);
+  const match = contentDisposition?.match(/filename=(?:"([^"]+)"|([^;]+))/i);
+  let fileName = match?.[1] ?? match?.[2];
+
+  if (fileName == null) {
+    // Fallback to original logic if regex fails (though unlikely for valid headers)
+    // or just throw error as before.
+    // The original logic was:
+    fileName = contentDisposition?.split(`filename=`)?.[1];
+  }
 
   if (fileName == null) {
     throw new Error(`No filename in content-disposition`);
   }
+
+  // Sanitize filename to prevent path traversal
+  fileName = path.basename(fileName);
 
   const destination = path.resolve(dir, fileName);
   const fileStream = createWriteStream(destination);


### PR DESCRIPTION
Identified and fixed a Path Traversal vulnerability in `src/utils/download-file.ts` where filenames from `Content-Disposition` headers were used without sanitization. This could allow malicious servers to write files outside the intended directory.

Changes:
- Added `path.basename()` sanitization to `fileName`.
- improved regex parsing for `Content-Disposition`.
- Added a security test to reproduce and verify the fix.
- Updated existing tests to mock `path.basename`.


---
*PR created automatically by Jules for task [8630019902739947831](https://jules.google.com/task/8630019902739947831) started by @ll1r1k-1337*