### PR TITLE
⚡ Bolt: Optimized NATS server startup check

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-02-26 - Optimize Stream Monitoring
+**Learning:** Monitoring child process `stderr` for a ready signal can be expensive if `data.toString()` is called on every chunk throughout the process lifetime.
+**Action:** Use a state flag (e.g., `isReady`) to stop checking once the signal is found. Also, use `Buffer.includes()` to search raw buffers instead of allocating strings when logging is disabled.

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -78,20 +78,32 @@ export class NatsServer {
         reject(err);
       });
 
+      let isReady = false;
+
       this.process.stderr.on(`data`, (data: unknown) => {
         // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        const dataStr = data?.toString();
+        const dataStr = verbose ? (data as any)?.toString() : null;
 
         if (verbose && dataStr != null) {
           logger.log(dataStr);
         }
 
-        if (dataStr?.includes(`Server is ready`) === true) {
-          if (verbose) {
-            logger.log(`NATS server is ready!`);
+        if (!isReady) {
+          // Optimization: Check buffer directly to avoid string conversion if not verbose
+          // and stop checking once ready.
+          const isReadyMatch =
+            dataStr != null
+              ? dataStr.includes(`Server is ready`)
+              : (data as any)?.includes(`Server is ready`);
+
+          if (isReadyMatch === true) {
+            isReady = true;
+            if (verbose) {
+              logger.log(`NATS server is ready!`);
+            }
+            resolve(this);
+            this.process?.unref();
           }
-          resolve(this);
-          this.process?.unref();
         }
       });
 


### PR DESCRIPTION
Optimized the `stderr` monitoring in `NatsServer` by introducing an `isReady` flag to stop checking for the "Server is ready" message once it has been found. Additionally, when verbose logging is disabled, the code now checks the raw buffer using `Buffer.includes()` instead of allocating a string for every chunk, reducing memory usage and CPU overhead.

This change ensures that the potentially high-volume stderr stream from the NATS server is processed more efficiently throughout the server's lifecycle.

---
*PR created automatically by Jules for task [5773204030615212858](https://jules.google.com/task/5773204030615212858) started by @ll1r1k-1337*