### PR TITLE
⚡ Bolt: Optimize high-volume stream parsing in NatsServer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - [High-volume stream optimization in NatsServer]
+**Learning:** For high-volume log streams (like `stderr` in `NatsServer`), using `Buffer.includes()` on binary chunks to detect state changes (e.g., "Server is ready") is significantly more efficient than calling `.toString()` on every chunk, as it avoids repeated string allocations. Also, introducing a state flag (`isReady`) to bypass the check entirely on subsequent chunks provides an O(1) skipping mechanism after the desired state is reached.
+**Action:** When monitoring data streams, use state flags to bypass expensive operations once the desired state is reached, and prefer operating directly on Buffers over converting to strings whenever possible, especially when only searching for a static marker.

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -78,15 +78,16 @@ export class NatsServer {
         reject(err);
       });
 
-      this.process.stderr.on(`data`, (data: unknown) => {
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        const dataStr = data?.toString();
+      let isReady = false;
+      const readyMarker = Buffer.from(`Server is ready`);
 
-        if (verbose && dataStr != null) {
-          logger.log(dataStr);
+      this.process.stderr.on(`data`, (data: Buffer) => {
+        if (verbose) {
+          logger.log(data.toString());
         }
 
-        if (dataStr?.includes(`Server is ready`) === true) {
+        if (!isReady && data.includes(readyMarker)) {
+          isReady = true;
           if (verbose) {
             logger.log(`NATS server is ready!`);
           }


### PR DESCRIPTION
💡 What: Replaced the naive `data.toString()` conversion and string `.includes()` with `Buffer.prototype.includes()` when parsing the NATS server `stderr` stream. Also added an `isReady` flag to completely bypass the check once the server is successfully started.
🎯 Why: The original code was unconditionally converting the binary standard error stream chunks to strings and searching through them even after the server had already reached a ready state. High-volume logging on this stream would continuously trigger unnecessary string allocations.
📊 Impact: Completely eliminates string allocations and substring search computations after the "Server is ready" message is detected, turning an O(N) stream processing pipeline into O(1) skipping per chunk (unless `verbose` mode is intentionally logging every line).
🔬 Measurement: Verify by running the standard `npm run test` and `npm run lint`. The NATS server should correctly identify when it is ready, and tests should pass exactly as before but with reduced CPU overhead during runtime.

---
*PR created automatically by Jules for task [16369734166690084536](https://jules.google.com/task/16369734166690084536) started by @ll1r1k-1337*