### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-01 - Path Traversal in File Download
+**Vulnerability:** The `downloadFile` function extracted the filename from the `Content-Disposition` header and used it directly in `path.resolve()`, allowing an attacker-controlled server to write files outside the intended directory via path traversal (e.g., `../../../etc/passwd`).
+**Learning:** Always sanitize filenames extracted from external sources (like HTTP headers) using `path.basename()` before using them in file system operations.
+**Prevention:** Use a robust regex to parse `Content-Disposition` and apply `path.basename()` to strip any directory components from the filename.

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,8 +14,12 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
+    mockBasename.mockImplementation((p) =>
+      p.split(`/`).pop().split(`\\`).pop(),
+    );
     jest.clearAllMocks();
   });
 
@@ -117,6 +121,35 @@ describe(`downloadFile`, () => {
     await expect(downloadFile(url)).rejects.toThrow(
       `Failed to download http://example.com/file.zip: Not Found`,
     );
+  });
+
+  it(`should prevent path traversal in filename`, async () => {
+    const url = `http://example.com/file.zip`;
+    const dir = `/tmp`;
+    const destination = `/tmp/file.zip`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename="../../../file.zip"`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockResolve.mockReturnValue(destination);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    const result = await downloadFile(url, dir);
+
+    expect(result).toBe(destination);
+    expect(mockFetch).toHaveBeenCalledWith(url, {});
+    expect(mockBasename).toHaveBeenCalledWith(`../../../file.zip`);
+    expect(mockResolve).toHaveBeenCalledWith(dir, `file.zip`);
+    expect(mockCreateWriteStream).toHaveBeenCalledWith(destination);
+    expect(mockPipeline).toHaveBeenCalledWith(`mockBody`, `mockWriteStream`);
   });
 
   it(`should throw error if filename is missing`, async () => {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,13 +36,18 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
-    .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+  const contentDisposition = response.headers.get(CONTENT_DISPOSITION_KEY);
+  const match = contentDisposition?.match(
+    /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i,
+  );
+  let fileName = match?.[1] ?? contentDisposition?.split(`filename=`)?.[1];
 
   if (fileName == null) {
     throw new Error(`No filename in content-disposition`);
   }
+
+  fileName = fileName.replace(/^["']|["']$/g, ``);
+  fileName = path.basename(fileName);
 
   const destination = path.resolve(dir, fileName);
   const fileStream = createWriteStream(destination);


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `downloadFile` function extracted the filename from the `Content-Disposition` header and used it directly in `path.resolve()`, allowing an attacker-controlled server to provide a malicious filename (e.g., `../../../etc/passwd`) to write files outside the intended destination directory.
🎯 **Impact:** An attacker could overwrite critical system files, potentially leading to remote code execution or system compromise.
🔧 **Fix:** Utilized a robust regex to parse the `Content-Disposition` header and applied `path.basename()` to the extracted filename to strip out any directory traversal components, ensuring files are always written to the designated `dir`. Quotes surrounding the filename are also properly removed. 
✅ **Verification:** Verified by running the existing unit tests and adding a new test `should prevent path traversal in filename` to ensure paths with `../../../` are successfully sanitized. All linting and tests pass.

---
*PR created automatically by Jules for task [16976343106833670854](https://jules.google.com/task/16976343106833670854) started by @ll1r1k-1337*