### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in downloadFile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-01 - Fix Path Traversal in downloadFile
+**Vulnerability:** The `downloadFile` function in `src/utils/download-file.ts` blindly extracted the filename from the `Content-Disposition` header and passed it directly to `path.resolve(dir, fileName)`. This allowed a malicious server to specify a filename with directory traversal payloads (like `../../etc/passwd`) to write files outside of the intended download directory.
+**Learning:** Naively splitting by `filename=` and not sanitizing the resulting filename from HTTP headers can lead to severe path traversal vulnerabilities, especially when downloading files to a local filesystem.
+**Prevention:** Always sanitize user-provided or externally-provided filenames when interacting with the file system. Use robust regexes for parsing complex headers and apply `path.basename()` to strip out directory paths, ensuring only the base filename is used.

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -8,7 +8,7 @@ jest.mock(`make-fetch-happen`);
 jest.mock(`fs`);
 jest.mock(`path`, () => ({
   resolve: jest.fn(),
-  basename: jest.fn((p) => p.split(`/`).pop()?.split(`\\`).pop() || p),
+  basename: jest.fn((p: string) => p.split(`/`).pop()?.split(`\\`).pop() ?? p),
 }));
 jest.mock(`stream/promises`);
 

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -6,7 +6,10 @@ import { pipeline } from 'stream/promises';
 
 jest.mock(`make-fetch-happen`);
 jest.mock(`fs`);
-jest.mock(`path`);
+jest.mock(`path`, () => ({
+  resolve: jest.fn(),
+  basename: jest.fn((p) => p.split(`/`).pop()?.split(`\\`).pop() || p),
+}));
 jest.mock(`stream/promises`);
 
 describe(`downloadFile`, () => {
@@ -27,6 +30,32 @@ describe(`downloadFile`, () => {
       ok: true,
       headers: {
         get: jest.fn().mockReturnValue(`attachment; filename=file.zip`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockResolve.mockReturnValue(destination);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    const result = await downloadFile(url, dir);
+
+    expect(result).toBe(destination);
+    expect(mockFetch).toHaveBeenCalledWith(url, {});
+    expect(mockResolve).toHaveBeenCalledWith(dir, `file.zip`);
+    expect(mockCreateWriteStream).toHaveBeenCalledWith(destination);
+    expect(mockPipeline).toHaveBeenCalledWith(`mockBody`, `mockWriteStream`);
+  });
+
+  it(`should download a file successfully with quoted filename`, async () => {
+    const url = `http://example.com/file.zip`;
+    const dir = `/tmp`;
+    const destination = `/tmp/file.zip`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest.fn().mockReturnValue(`attachment; filename="file.zip"`),
       },
       body: `mockBody`,
     };
@@ -117,6 +146,35 @@ describe(`downloadFile`, () => {
     await expect(downloadFile(url)).rejects.toThrow(
       `Failed to download http://example.com/file.zip: Not Found`,
     );
+  });
+
+  it(`should strip path traversal payloads and surrounding quotes from filename`, async () => {
+    const url = `http://example.com/file.zip`;
+    const dir = `/tmp`;
+    const destination = `/tmp/passwd`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename="../../etc/passwd"`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockResolve.mockReturnValue(destination);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    const result = await downloadFile(url, dir);
+
+    expect(result).toBe(destination);
+    expect(mockFetch).toHaveBeenCalledWith(url, {});
+    // Should use path.basename to extract 'passwd'
+    expect(mockResolve).toHaveBeenCalledWith(dir, `passwd`);
+    expect(mockCreateWriteStream).toHaveBeenCalledWith(destination);
+    expect(mockPipeline).toHaveBeenCalledWith(`mockBody`, `mockWriteStream`);
   });
 
   it(`should throw error if filename is missing`, async () => {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,15 +36,26 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
-    .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+  const contentDisposition = response.headers.get(CONTENT_DISPOSITION_KEY);
+  let fileName: string | undefined;
 
-  if (fileName == null) {
+  if (contentDisposition != null) {
+    const match = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i.exec(
+      contentDisposition,
+    );
+    if (match?.[1] != null) {
+      fileName = match[1].replace(/^['"]|['"]$/g, ``);
+    }
+  }
+
+  if (fileName == null || fileName.trim() === ``) {
     throw new Error(`No filename in content-disposition`);
   }
 
-  const destination = path.resolve(dir, fileName);
+  // Security Enhancement: Prevent path traversal by extracting only the base name.
+  // This ensures malicious servers cannot write outside the intended directory.
+  const safeFileName = path.basename(fileName);
+  const destination = path.resolve(dir, safeFileName);
   const fileStream = createWriteStream(destination);
 
   await pipeline(response.body, fileStream);


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `downloadFile` function in `src/utils/download-file.ts` extracted filenames from the `Content-Disposition` HTTP header and passed them to `path.resolve` without sanitization. Malicious servers could respond with an attachment name containing directory traversal payloads (like `../../etc/passwd`), leading to arbitrary file write outside the intended download directory.
🎯 **Impact:** If exploited, a malicious NATS server or any intercepted HTTP payload could overwrite critical system files, potentially leading to arbitrary code execution or system compromise.
🔧 **Fix:** Refactored header extraction logic to use a robust regex parsing mechanism. Crucially, the extracted filename is now passed through `path.basename()` to strip out any directory paths, ensuring only the base file name is utilized safely. Added comments detailing the security measures.
✅ **Verification:** Verified by executing `npm run test src/utils/download-file.spec.ts` where specific unit tests have been added to assert that payloads like `../../etc/passwd` correctly resolve to the safe filename `passwd`. `npm run lint` and `npm test` successfully completed.

---
*PR created automatically by Jules for task [8497996109311750192](https://jules.google.com/task/8497996109311750192) started by @ll1r1k-1337*