### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in downloadFile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-13 - Path Traversal via Content-Disposition in Download File
+**Vulnerability:** The `downloadFile` function unsafely extracted the `filename` from the `Content-Disposition` header using a naive string split and directly concatenated it into the file system path using `path.resolve()`. If a remote server sends a malicious header like `filename="../../../etc/passwd"`, this would result in a path traversal vulnerability and arbitrary file overwrite.
+**Learning:** Naively trusting user-supplied or remote-supplied input for filenames in HTTP headers, especially `Content-Disposition`, is dangerous. Proper extraction requires regular expressions that account for optional quotes and encoding.
+**Prevention:** Always use `path.basename()` when dealing with external filenames to strip out any directory paths and prevent path traversal attacks. Additionally, use robust regex to parse the filename attribute.

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,9 +14,11 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockBasename.mockImplementation((p: string) => p.split(`/`).pop() ?? p);
   });
 
   it(`should download a file successfully`, async () => {
@@ -117,6 +119,34 @@ describe(`downloadFile`, () => {
     await expect(downloadFile(url)).rejects.toThrow(
       `Failed to download http://example.com/file.zip: Not Found`,
     );
+  });
+
+  it(`should sanitize path traversal in content-disposition filename`, async () => {
+    const url = `http://example.com/file.zip`;
+    const dir = `/tmp`;
+    const destination = `/tmp/passwd`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename="../../../etc/passwd"`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockResolve.mockReturnValue(destination);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    const result = await downloadFile(url, dir);
+
+    expect(result).toBe(destination);
+    expect(mockFetch).toHaveBeenCalledWith(url, {});
+    expect(mockResolve).toHaveBeenCalledWith(dir, `passwd`);
+    expect(mockCreateWriteStream).toHaveBeenCalledWith(destination);
+    expect(mockPipeline).toHaveBeenCalledWith(`mockBody`, `mockWriteStream`);
   });
 
   it(`should throw error if filename is missing`, async () => {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,13 +36,19 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
-    .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+  const contentDisposition = response.headers.get(CONTENT_DISPOSITION_KEY);
+  const fileNameMatch = contentDisposition?.match(
+    /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i,
+  );
+  let fileName =
+    fileNameMatch != null ? fileNameMatch[1].replace(/['"]/g, ``) : null;
 
   if (fileName == null) {
     throw new Error(`No filename in content-disposition`);
   }
+
+  // Security: Prevent path traversal by extracting only the base name
+  fileName = path.basename(fileName);
 
   const destination = path.resolve(dir, fileName);
   const fileStream = createWriteStream(destination);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `downloadFile` function unsafely extracted the `filename` from the `Content-Disposition` header using a naive string split and directly appended it via `path.resolve()`. A malicious server could supply a payload like `filename="../../../etc/passwd"` to write arbitrary files.
🎯 Impact: Arbitrary file overwrite or write leading to remote code execution or system compromise.
🔧 Fix: Updated the `filename` extraction to use a robust regular expression that handles optional quotes correctly. More importantly, applied `path.basename()` to the extracted filename to enforce that only the base filename is used, safely stripping out any traversal elements (e.g., `../`).
✅ Verification: Covered by a new test case in `download-file.spec.ts` asserting `../../../etc/passwd` is sanitized to `passwd`. Ran `npm test` and `npm run lint` successfully.

---
*PR created automatically by Jules for task [10506100263244602832](https://jules.google.com/task/10506100263244602832) started by @ll1r1k-1337*