### PR TITLE
⚡ Bolt: Optimize NATS server stderr stream handling

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Optimize High-Volume Data Streams
+**Learning:** For long-running child processes emitting a high volume of logs to stderr (like NatsServer), continuously converting binary chunks to strings via `.toString()` just to check for readiness creates an unnecessary performance bottleneck that scales with the lifetime of the process.
+**Action:** When monitoring data streams for a specific one-time event (like "Server is ready"), use state flags (e.g., `isReady`) to completely bypass check logic once the desired state is reached. Additionally, use `Buffer.includes()` on the raw binary chunks instead of coercing them to strings to find indicators, avoiding expensive string allocations.

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -78,15 +78,20 @@ export class NatsServer {
         reject(err);
       });
 
+      // ⚡ Bolt: Optimize stream handling by tracking ready state
+      // Avoids expensive string allocations and scans for every log line emitted over the server's lifetime
+      let isReady = false;
+      const readyIndicator = Buffer.from(`Server is ready`);
       this.process.stderr.on(`data`, (data: unknown) => {
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        const dataStr = data?.toString();
+        const chunk = data as Buffer;
 
-        if (verbose && dataStr != null) {
-          logger.log(dataStr);
+        if (verbose) {
+          logger.log(chunk.toString());
         }
 
-        if (dataStr?.includes(`Server is ready`) === true) {
+        // ⚡ Bolt: Use binary inclusion check before converting to string, and skip entirely once ready
+        if (!isReady && chunk.includes(readyIndicator)) {
+          isReady = true;
           if (verbose) {
             logger.log(`NATS server is ready!`);
           }


### PR DESCRIPTION
💡 **What**: The optimization introduces an `isReady` state flag and uses `Buffer.includes()` directly on raw binary chunks emitted by the NATS server `stderr` stream, bypassing string conversion except when `verbose` logging is enabled. Once the server is ready, the log parsing check logic is entirely skipped.

🎯 **Why**: The NATS server is a long-running process that can emit a high volume of logs to `stderr`. Previously, the application coerced every single binary chunk emitted by `stderr` to a string using `.toString()` and scanned it with `.includes('Server is ready')` for the entire lifetime of the process. This creates unnecessary string allocation overhead and CPU cycles for logs we don't care about after initialization.

📊 **Impact**: Reduces CPU overhead and GC pressure (string allocations) linearly scaling with the number of log lines emitted by the NATS server over its lifetime. The checking logic becomes `O(1)` (runs only until server is ready) instead of `O(N)` where N is total log lines emitted by the server.

🔬 **Measurement**: Verify by running `npm run test`. All tests run perfectly, indicating the server startup is still successfully detected without regressions. Code was tested using existing stream-related mock cases. The performance gain is theoretical but significant over the lifespan of long-lived integration test environments.

---
*PR created automatically by Jules for task [2706810102973746869](https://jules.google.com/task/2706810102973746869) started by @ll1r1k-1337*