### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-03 - Path Traversal in File Download
+**Vulnerability:** The `downloadFile` function uses `path.resolve(dir, fileName)` where `fileName` is extracted from the `Content-Disposition` header sent by the remote server. This allows a malicious server to respond with `Content-Disposition: attachment; filename=../../../tmp/evil.sh` and write arbitrary files anywhere on the system.
+**Learning:** `Content-Disposition` headers are untrusted input. Directly concatenating or resolving them against a target directory leads to path traversal vulnerabilities.
+**Prevention:** Always use `path.basename()` to sanitize filenames extracted from `Content-Disposition` or other external sources before using them in file system operations.

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -17,6 +17,17 @@ describe(`downloadFile`, () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockResolve.mockImplementation(
+      (dir: string, file: string) => `${dir}/${file}`,
+    );
+    (path.basename as jest.Mock).mockImplementation((p: string) => {
+      const parts = p.split(`/`);
+      const last = parts[parts.length - 1];
+      if (last != null && last !== ``) {
+        return last;
+      }
+      return p;
+    });
   });
 
   it(`should download a file successfully`, async () => {
@@ -117,6 +128,29 @@ describe(`downloadFile`, () => {
     await expect(downloadFile(url)).rejects.toThrow(
       `Failed to download http://example.com/file.zip: Not Found`,
     );
+  });
+
+  it(`should sanitize filename to prevent path traversal`, async () => {
+    const url = `http://example.com/file.zip`;
+    const dir = `/tmp`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename="../../../etc/passwd"`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    const result = await downloadFile(url, dir);
+
+    expect(result).toBe(`/tmp/passwd`);
+    expect(mockResolve).toHaveBeenCalledWith(dir, `passwd`);
   });
 
   it(`should throw error if filename is missing`, async () => {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,13 +36,18 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
+  let fileName = response.headers
     .get(CONTENT_DISPOSITION_KEY)
     ?.split(`filename=`)?.[1];
 
   if (fileName == null) {
     throw new Error(`No filename in content-disposition`);
   }
+
+  // Sanitize the filename to prevent path traversal
+  // Remove any quotes that might be around the filename
+  fileName = fileName.replace(/['"]/g, ``);
+  fileName = path.basename(fileName);
 
   const destination = path.resolve(dir, fileName);
   const fileStream = createWriteStream(destination);


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Path Traversal / Arbitrary File Write in `downloadFile`. The filename is extracted from the `Content-Disposition` header and immediately resolved against the target directory without sanitization. A malicious server could return a header like `Content-Disposition: attachment; filename="../../../etc/passwd"` to overwrite sensitive files anywhere on the system.
🎯 **Impact:** If an attacker can control the server or perform a Man-in-the-Middle attack, they could achieve remote code execution by overwriting configuration files or binaries.
🔧 **Fix:** Added `path.basename()` to properly sanitize the filename extracted from the header. Also added a strip of single or double quotes to ensure the filename isn't padded by string characters which helps clean the result.
✅ **Verification:** Unit test added and successfully failing without the fix. After the fix, all tests pass successfully without issues. Tested with `npm run lint` and `npm test`. Learnings added to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [872419205535361170](https://jules.google.com/task/872419205535361170) started by @ll1r1k-1337*