### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in Content-Disposition downloads

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-06 - Path Traversal Vulnerability in Filename Extraction
+**Vulnerability:** The extracted filename from `Content-Disposition` headers in `src/utils/download-file.ts` lacked sanitization, allowing potential path traversal attacks (e.g., `filename="../../../etc/passwd"`).
+**Learning:** `make-fetch-happen` (or node-fetch) headers parse Content-Disposition as raw strings. The previous extraction using `.split('filename=')[1]` also failed to handle quoted filenames correctly, compounding extraction errors and exposing directory traversal paths.
+**Prevention:** Apply strict regex to match quoted and unquoted filenames accurately. Strip any leading/trailing quotes, and use `path.basename()` consistently to strip any relative directory traversal path components.

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -17,6 +17,13 @@ describe(`downloadFile`, () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    // 🛡️ Sentinel: explicitly mock path.basename to work across platforms for testing
+    const originalPath = jest.requireActual(`path`);
+    mockResolve.mockImplementation(originalPath.resolve);
+    (path.basename as unknown as jest.Mock).mockImplementation((p: string) => {
+      return p.split(`/`).pop()?.split(`\\`).pop() ?? p;
+    });
   });
 
   it(`should download a file successfully`, async () => {
@@ -133,5 +140,50 @@ describe(`downloadFile`, () => {
     await expect(downloadFile(url)).rejects.toThrow(
       `No filename in content-disposition`,
     );
+  });
+
+  it(`should mitigate path traversal when extracting filename`, async () => {
+    const url = `http://example.com/file.zip`;
+    const dir = `/tmp`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename="../../../etc/passwd"`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    await downloadFile(url, dir);
+
+    expect(mockFetch).toHaveBeenCalledWith(url, {});
+    expect(mockResolve).toHaveBeenCalledWith(dir, `passwd`);
+  });
+
+  it(`should handle quoted filenames`, async () => {
+    const url = `http://example.com/file.zip`;
+    const dir = `/tmp`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename="quoted-file.zip"`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    await downloadFile(url, dir);
+
+    expect(mockResolve).toHaveBeenCalledWith(dir, `quoted-file.zip`);
   });
 });

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,13 +36,17 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
-    .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+  const contentDisposition = response.headers.get(CONTENT_DISPOSITION_KEY);
+  let fileName = contentDisposition?.match(
+    /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i,
+  )?.[1];
 
   if (fileName == null) {
     throw new Error(`No filename in content-disposition`);
   }
+
+  // 🛡️ Sentinel: Sanitize filename to prevent path traversal
+  fileName = path.basename(fileName.replace(/^(['"])(.*)\1$/, `$2`).trim());
 
   const destination = path.resolve(dir, fileName);
   const fileStream = createWriteStream(destination);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Potential path traversal via unsafe filename extraction from `Content-Disposition` header in file downloads.
🎯 Impact: Attackers could manipulate headers to write files to unintended paths (e.g. `../../../etc/passwd`) within the server filesystem.
🔧 Fix: Adopted a strict regex to parse out valid filenames, explicitly stripping quotes. Forced standard sanitization using `path.basename()` to eliminate relative path traversal characters. Added comprehensive regression tests.
✅ Verification: Ran `npm run test` executing targeted path traversal tests within `src/utils/download-file.spec.ts`. All logic correctly falls back to sanitized base filenames.

---
*PR created automatically by Jules for task [14208715962977733945](https://jules.google.com/task/14208715962977733945) started by @ll1r1k-1337*