### PR TITLE
⚡ Bolt: [performance improvement] Optimize stderr processing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-07 - Optimize NatsServer stderr processing
+**Learning:** For high-volume log streams (like stderr from a spawned child process, e.g., NatsServer), continuously converting binary chunks to strings (`.toString()`) and searching them for readiness messages after the server is already ready causes unnecessary CPU load and string allocations.
+**Action:** Use a state flag (`isReady`) to early-return and completely bypass expensive operations (like `.toString()`) once the desired state has been reached, provided the verbose logging is turned off. If `verbose` is true, we still need to process the stream to log it, but otherwise we can skip processing completely.

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -61,6 +61,8 @@ export class NatsServer {
     const { args, ip, port = await getFreePort(), binPath } = config;
 
     return await new Promise((resolve, reject) => {
+      let isReady = false;
+
       this.process = child_process.spawn(
         binPath,
         [`--addr`, ip, `--port`, port.toString(), ...args],
@@ -79,6 +81,19 @@ export class NatsServer {
       });
 
       this.process.stderr.on(`data`, (data: unknown) => {
+        if (!verbose && isReady) {
+          return;
+        }
+
+        if (!verbose && Buffer.isBuffer(data)) {
+          if (!isReady && data.includes(`Server is ready`)) {
+            isReady = true;
+            resolve(this);
+            this.process?.unref();
+          }
+          return;
+        }
+
         // eslint-disable-next-line @typescript-eslint/no-base-to-string
         const dataStr = data?.toString();
 
@@ -87,6 +102,7 @@ export class NatsServer {
         }
 
         if (dataStr?.includes(`Server is ready`) === true) {
+          isReady = true;
           if (verbose) {
             logger.log(`NATS server is ready!`);
           }


### PR DESCRIPTION
💡 **What**: Added an early return to the NATS child process `stderr` log stream in `NatsServer.start()`. It tracks the `isReady` state and completely skips processing the `Buffer` objects into Strings and searching them for the readiness message once the server is already ready (and verbose is turned off).
🎯 **Why**: For high-volume log streams like the `stderr` from the spawned NATS process, continually converting binary chunks to strings (`.toString()`) just to scan them degrades performance and causes unnecessary memory pressure and garbage collection overhead.
📊 **Impact**: Considerably reduces CPU usage and memory footprint during the lifespan of the `NatsServer` instance when verbose logging is disabled.
🔬 **Measurement**: Verification is done through running the existing test suite (`npm test`), which verifies no behavior is changed. In production-like environments running `nats-memory-server` heavily, you would see fewer string allocations and garbage collection cycles over time.

---
*PR created automatically by Jules for task [3720900305569091145](https://jules.google.com/task/3720900305569091145) started by @ll1r1k-1337*