### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in download file

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Path Traversal via Content-Disposition
+**Vulnerability:** The application was extracting filenames directly from the `content-disposition` header of remote responses and passing them to `path.resolve()` without sanitization. An attacker controlling the remote endpoint could supply a filename like `../../../etc/passwd` to overwrite arbitrary files outside the intended download directory (Path Traversal).
+**Learning:** External inputs, including HTTP headers (which often feel "system generated"), are untrusted vectors and can be manipulated. Any file operation (read, write, resolve) based on an external input needs validation and containment.
+**Prevention:** Always apply `path.basename()` to any path components derived from user input or external responses to strip away any directory traversal sequences (like `../`). Combine with stripping unexpected characters (like surrounding quotes from headers) before performing file I/O operations.

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,9 +14,13 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockBasename.mockImplementation(
+      (p: string) => p.split(`/`).pop()?.split(`\\`).pop() ?? ``,
+    );
   });
 
   it(`should download a file successfully`, async () => {
@@ -132,6 +136,48 @@ describe(`downloadFile`, () => {
 
     await expect(downloadFile(url)).rejects.toThrow(
       `No filename in content-disposition`,
+    );
+  });
+
+  it(`should prevent path traversal by sanitizing the filename`, async () => {
+    const url = `http://example.com/file.zip`;
+    const dir = `/tmp`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename="../../../etc/passwd"`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockResolve.mockReturnValue(`/tmp/passwd`);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    await downloadFile(url, dir);
+
+    expect(mockBasename).toHaveBeenCalledWith(`../../../etc/passwd`);
+    expect(mockResolve).toHaveBeenCalledWith(dir, `passwd`);
+  });
+
+  it(`should throw error if sanitized filename is empty`, async () => {
+    const url = `http://example.com/file.zip`;
+    const dir = `/tmp`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest.fn().mockReturnValue(`attachment; filename=""`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+
+    await expect(downloadFile(url, dir)).rejects.toThrow(
+      `Invalid filename in content-disposition`,
     );
   });
 });

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -44,7 +44,16 @@ export async function downloadFile(
     throw new Error(`No filename in content-disposition`);
   }
 
-  const destination = path.resolve(dir, fileName);
+  // 🛡️ Sentinel: Sanitize filename to prevent Path Traversal vulnerabilities
+  const sanitizedFileName = path.basename(
+    fileName.replace(/^(['"])(.*)\1$/, `$2`).trim(),
+  );
+
+  if (sanitizedFileName === ``) {
+    throw new Error(`Invalid filename in content-disposition`);
+  }
+
+  const destination = path.resolve(dir, sanitizedFileName);
   const fileStream = createWriteStream(destination);
 
   await pipeline(response.body, fileStream);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `downloadFile` function in `src/utils/download-file.ts` extracted the `fileName` directly from the remote server's `content-disposition` header and resolved it using `path.resolve(dir, fileName)` without sanitization. An attacker controlling the remote endpoint could supply a filename like `../../../etc/passwd` to execute a Path Traversal attack, overwriting arbitrary files outside the intended download directory.
🎯 Impact: This allows arbitrary file write on the host system running the application, leading to severe system compromise, data loss, or Remote Code Execution (RCE) depending on the overwritten file.
🔧 Fix: Sanitized the extracted `fileName` by first applying a regex replacement to trim any surrounding quotes or spaces, and then applying `path.basename()` to securely strip all directory path components and traversal sequences. If the resulting sanitized string is empty, the function safely aborts by throwing an error instead of corrupting file system context.
✅ Verification: Tested against a local mock server response with an empty file name, a standard file name, and a path traversal payload `../../../etc/passwd`. Verified that the file operations appropriately evaluate and strip payloads like `../../../etc/passwd` to `passwd` and that `path.resolve` outputs a safe path relative to the intended directory bounds.

All unit and integration tests under `npm test` are successfully passing, and the code style is verified using `npm run lint` and `npm run format`.

---
*PR created automatically by Jules for task [10078533361891777127](https://jules.google.com/task/10078533361891777127) started by @ll1r1k-1337*