### PR TITLE
⚡ Bolt: Reduce object allocations in NatsServerBuilder

### DIFF
--- a/src/nats-server.builder.ts
+++ b/src/nats-server.builder.ts
@@ -6,9 +6,12 @@ import {
 } from './index';
 
 export class NatsServerBuilder {
-  private options: NatsServerOptions = DEFAULT_NATS_SERVER_OPTIONS;
+  private readonly options: NatsServerOptions;
 
   constructor(options?: Partial<NatsServerOptions>) {
+    // Clone DEFAULT_NATS_SERVER_OPTIONS so we don't mutate the shared global object
+    this.options = { ...DEFAULT_NATS_SERVER_OPTIONS };
+
     if (options != null) {
       this.options = { ...this.options, ...options };
     }
@@ -19,32 +22,32 @@ export class NatsServerBuilder {
   }
 
   setBinPath(binPath: string): this {
-    this.options = { ...this.options, binPath };
+    this.options.binPath = binPath;
     return this;
   }
 
   setVerbose(verbose: boolean): this {
-    this.options = { ...this.options, verbose };
+    this.options.verbose = verbose;
     return this;
   }
 
   setPort(port: number): this {
-    this.options = { ...this.options, port };
+    this.options.port = port;
     return this;
   }
 
   setIp(ip: string): this {
-    this.options = { ...this.options, ip };
+    this.options.ip = ip;
     return this;
   }
 
   setArgs(args: string[]): this {
-    this.options = { ...this.options, args };
+    this.options.args = args;
     return this;
   }
 
   setLogger(logger: Logger): this {
-    this.options = { ...this.options, logger };
+    this.options.logger = logger;
     return this;
   }
 


### PR DESCRIPTION
💡 What: Refactored `NatsServerBuilder` setter methods to mutate `this.options` directly instead of using object spread syntax (`...this.options`) on every call. Added `readonly` modifier and cloned `DEFAULT_NATS_SERVER_OPTIONS` in the constructor to prevent shared state mutation.

🎯 Why: Every call to a builder method (like `setPort`, `setVerbose`, etc.) was previously creating a completely new object via spread syntax. For a chained builder pattern, this creates unnecessary short-lived objects that increase garbage collection overhead. Mutating a single cloned object is significantly more efficient.

📊 Impact: Reduces object allocations during builder chaining. If a user calls `NatsServerBuilder.create().setPort(4222).setVerbose(false).setIp('127.0.0.1').build()`, it now creates 1 options object instead of 4.

🔬 Measurement: Run `npm run lint` and `npm test` to verify no functionality or type safety was broken. The tests already assert that custom options are properly applied and default options are not mutated.

---
*PR created automatically by Jules for task [9398752742598005963](https://jules.google.com/task/9398752742598005963) started by @ll1r1k-1337*