### PR TITLE
⚡ Bolt: Optimize NatsServer stderr stream processing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-20 - NatsServer stderr Buffer Optimization
+**Learning:** High-volume log streams (like `stderr` in `NatsServer`) are bottlenecked by continuous `.toString()` calls on every chunk, even when the desired state flag is already set.
+**Action:** Introduce an `isReady` state flag for early return, and utilize `Buffer.includes()` on binary chunks instead of calling `.toString()` to bypass expensive string allocations.

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -78,15 +78,33 @@ export class NatsServer {
         reject(err);
       });
 
+      let isReady = false;
+
       this.process.stderr.on(`data`, (data: unknown) => {
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        const dataStr = data?.toString();
+        if (isReady && !verbose) {
+          return; // ⚡ Bolt: Early return to skip processing if already ready and not verbose
+        }
+
+        // ⚡ Bolt: Check if buffer includes string without allocation first
+        const isServerReady =
+          Buffer.isBuffer(data) && data.includes(`Server is ready`);
+
+        let dataStr: string | undefined;
+
+        if (verbose || (!isServerReady && !isReady)) {
+          // eslint-disable-next-line @typescript-eslint/no-base-to-string
+          dataStr = data?.toString();
+        }
 
         if (verbose && dataStr != null) {
           logger.log(dataStr);
         }
 
-        if (dataStr?.includes(`Server is ready`) === true) {
+        if (
+          !isReady &&
+          (isServerReady || dataStr?.includes(`Server is ready`) === true)
+        ) {
+          isReady = true;
           if (verbose) {
             logger.log(`NATS server is ready!`);
           }


### PR DESCRIPTION
💡 **What**: Added an early return and state flag `isReady` to the `stderr` processing logic of `NatsServer`, and utilized `Buffer.includes()` instead of `data?.toString()` to check for readiness.

🎯 **Why**: High-volume log streams naturally bottleneck on CPU and memory when continuous allocations like `.toString()` are called on every chunk. Once the server achieves readiness, continuing to parse and evaluate the binary stream string contents is wasteful when `verbose` mode is off.

📊 **Impact**: Prevents continuous string allocation (`.toString()`) and stream processing overhead on all `stderr` chunks emitted after the server initially reports "Server is ready", provided `verbose` logging is disabled.

🔬 **Measurement**: Verify existing functionality with `npm run lint` and `npm test` to ensure NATS startup readiness is still successfully detected without regression.

---
*PR created automatically by Jules for task [2373058127044215756](https://jules.google.com/task/2373058127044215756) started by @ll1r1k-1337*