### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in file download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-11 - Path Traversal in File Download
+**Vulnerability:** Path traversal risk because `downloadFile` parses `content-disposition` filename header and uses it directly in `path.resolve()`.
+**Learning:** The previous implementation failed to strip directory components from the filename derived from network responses.
+**Prevention:** Always use `path.basename()` to sanitize user or external input before using it to resolve file paths.

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -1,0 +1,45 @@
+import { downloadFile } from './download-file';
+import fetch from 'make-fetch-happen';
+import fs from 'fs';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+
+jest.mock(`make-fetch-happen`);
+jest.mock(`fs`);
+jest.mock(`stream/promises`);
+
+describe(`downloadFile security`, () => {
+  const mockFetch = fetch as unknown as jest.Mock;
+  const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
+  const mockPipeline = pipeline as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`should prevent path traversal when filename contains directory components`, async () => {
+    const url = `http://example.com/evil`;
+    const dir = `/safe/dir`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename="../../../../etc/passwd"`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    const result = await downloadFile(url, dir);
+
+    // Expect the destination to be safely resolved inside the intended directory
+    expect(result).toBe(path.resolve(`/safe/dir`, `passwd`));
+    expect(mockCreateWriteStream).toHaveBeenCalledWith(
+      path.resolve(`/safe/dir`, `passwd`),
+    );
+  });
+});

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -6,7 +6,10 @@ import { pipeline } from 'stream/promises';
 
 jest.mock(`make-fetch-happen`);
 jest.mock(`fs`);
-jest.mock(`path`);
+jest.mock(`path`, () => ({
+  resolve: jest.fn(),
+  basename: (p: string) => p.split(`/`).pop()?.split(`\\`).pop(),
+}));
 jest.mock(`stream/promises`);
 
 describe(`downloadFile`, () => {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,13 +36,17 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
+  let fileName = response.headers
     .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+    ?.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i)?.[1];
 
   if (fileName == null) {
     throw new Error(`No filename in content-disposition`);
   }
+
+  fileName = fileName.replace(/^(['"])(.*)\1$/, `$2`).trim();
+  // Sanitize filename to prevent path traversal
+  fileName = path.basename(fileName);
 
   const destination = path.resolve(dir, fileName);
   const fileStream = createWriteStream(destination);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `downloadFile` function was vulnerable to path traversal because it used the `filename` extracted from the `Content-Disposition` HTTP header directly in `path.resolve()`. A malicious server could supply a filename like `../../../../../etc/passwd` to overwrite arbitrary files on the system where the code is executing.
🎯 Impact: A malicious remote server could achieve arbitrary file write capabilities and execute Remote Code Execution (RCE) or overwrite critical configuration files.
🔧 Fix: Added robust regex parsing of the `Content-Disposition` header and applied `path.basename()` to extract only the actual filename, effectively preventing any directory components from being resolved.
✅ Verification: Run `npm run test` (including `src/utils/download-file.security.spec.ts`) and `npm run build`.

---
*PR created automatically by Jules for task [10033847432098016778](https://jules.google.com/task/10033847432098016778) started by @ll1r1k-1337*