### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in file download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-12 - Fix path traversal vulnerability in Content-Disposition header
+**Vulnerability:** The filename extracted from the Content-Disposition header in file downloads was passed directly to path.resolve without sanitization. An attacker controlling the download URL could return a filename like "../../../etc/passwd" or "/etc/passwd", leading to arbitrary file write outside the intended directory.
+**Learning:** Path components parsed from remote server headers must always be treated as untrusted input.
+**Prevention:** Always sanitize downloaded filenames by extracting only the base name using `path.basename()` before resolving them against the destination directory.

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -6,7 +6,14 @@ import { pipeline } from 'stream/promises';
 
 jest.mock(`make-fetch-happen`);
 jest.mock(`fs`);
-jest.mock(`path`);
+jest.mock(`path`, () => {
+  const actual = jest.requireActual(`path`);
+  return {
+    ...actual,
+    resolve: jest.fn(),
+    basename: (p: string) => p.split(`/`).pop()?.split(`\\`).pop(),
+  };
+});
 jest.mock(`stream/promises`);
 
 describe(`downloadFile`, () => {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,13 +36,16 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
+  let fileName = response.headers
     .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+    ?.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i)?.[1];
 
   if (fileName == null) {
     throw new Error(`No filename in content-disposition`);
   }
+
+  // Remove quotes if present and secure against path traversal
+  fileName = path.basename(fileName.replace(/^(['"])(.*)\1$/, `$2`).trim());
 
   const destination = path.resolve(dir, fileName);
   const fileStream = createWriteStream(destination);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `downloadFile` function blindly parsed filenames from remote `Content-Disposition` headers and resolved them without sanitization, leading to an arbitrary file write path traversal vulnerability.
🎯 Impact: An attacker controlling a download URL or compromising the download server could serve files named `../../../etc/passwd` or similar relative paths, forcing the application to write files anywhere on the system.
🔧 Fix: Hardened the `Content-Disposition` parsing to more robustly extract the filename and applied `path.basename()` to securely strip all path components and only extract the final base filename before writing.
✅ Verification: Tests were updated, and validation passes successfully without breaking normal downloads.

---
*PR created automatically by Jules for task [17073323263045929812](https://jules.google.com/task/17073323263045929812) started by @ll1r1k-1337*