### PR TITLE
⚡ Bolt: Optimize stderr stream parsing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-03-13 - Optimize High-Volume stderr Stream Processing
+**Learning:** Calling `.toString()` on every `stderr` chunk for a long-running child process creates significant memory allocation overhead. High-volume streams shouldn't perform string conversion unless strictly necessary (e.g. for verbose logging).
+**Action:** Introduce an `isReady` state flag to early-return from the data handler when processing is no longer needed. Check `Buffer.isBuffer(data)` and use `data.includes()` on binary chunks to check for ready messages without expensive string allocations.

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -78,20 +78,36 @@ export class NatsServer {
         reject(err);
       });
 
+      let isReady = false;
       this.process.stderr.on(`data`, (data: unknown) => {
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        const dataStr = data?.toString();
-
-        if (verbose && dataStr != null) {
-          logger.log(dataStr);
+        // ⚡ Bolt: early return to skip expensive processing after ready
+        if (isReady && !verbose) {
+          return;
         }
 
-        if (dataStr?.includes(`Server is ready`) === true) {
-          if (verbose) {
-            logger.log(`NATS server is ready!`);
+        let dataStr: string | undefined;
+        if (verbose) {
+          // eslint-disable-next-line @typescript-eslint/no-base-to-string
+          dataStr = data?.toString();
+          if (dataStr != null) {
+            logger.log(dataStr);
           }
-          resolve(this);
-          this.process?.unref();
+        }
+
+        if (!isReady) {
+          // ⚡ Bolt: avoid expensive string allocation on binary stream checks
+          const isReadyMsg = Buffer.isBuffer(data)
+            ? data.includes(`Server is ready`)
+            : (dataStr ?? data?.toString())?.includes(`Server is ready`);
+
+          if (isReadyMsg === true) {
+            isReady = true;
+            if (verbose) {
+              logger.log(`NATS server is ready!`);
+            }
+            resolve(this);
+            this.process?.unref();
+          }
         }
       });
 


### PR DESCRIPTION
💡 What: Added an early return using an `isReady` state and replaced `.toString()` with binary `Buffer.includes()` checks on the child process `stderr` stream in `NatsServer`.
🎯 Why: `stderr` chunks arrive continuously while the server runs. Continually allocating strings from binary chunks just to search for "Server is ready" when the server is already ready is extremely wasteful and causes unnecessary garbage collection pressure.
📊 Impact: Eliminates unbounded string allocations per stream chunk once the server is ready, preventing excessive CPU/memory consumption.
🔬 Measurement: Observe memory allocation rates and garbage collection pauses when running the nats-server under load, or run the test suite to confirm functionality still passes.

---
*PR created automatically by Jules for task [17523902917160974696](https://jules.google.com/task/17523902917160974696) started by @ll1r1k-1337*