### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in file download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-15 - Prevent Path Traversal in Content-Disposition Filenames
+**Vulnerability:** The filename extracted from the `Content-Disposition` header was directly used in `path.resolve()`, allowing path traversal (e.g., `../../../etc/passwd`) if a malicious server sends an evil filename.
+**Learning:** Always sanitize filenames from untrusted sources (like external HTTP responses) using `path.basename()` before using them in file system operations. Also, robust regex parsing is required for header values to handle quotes properly.
+**Prevention:** Use regex `/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i`, remove wrapping quotes, and sanitize using `path.basename()`.

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -17,6 +17,12 @@ describe(`downloadFile`, () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    // We need to provide a mock implementation for path.basename to work since it is mocked globally
+    const mockBasename = path.basename as unknown as jest.Mock;
+    mockBasename.mockImplementation(
+      (p: string) => p.split(`/`).pop()?.split(`\\`).pop() ?? p,
+    );
   });
 
   it(`should download a file successfully`, async () => {
@@ -32,6 +38,7 @@ describe(`downloadFile`, () => {
     };
 
     mockFetch.mockResolvedValue(mockResponse);
+
     mockResolve.mockReturnValue(destination);
     mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
     mockPipeline.mockResolvedValue(undefined);
@@ -57,6 +64,7 @@ describe(`downloadFile`, () => {
     };
 
     mockFetch.mockResolvedValue(mockResponse);
+
     mockResolve.mockReturnValue(`/tmp/file.zip`);
     mockPipeline.mockResolvedValue(undefined);
 
@@ -77,6 +85,7 @@ describe(`downloadFile`, () => {
     };
 
     mockFetch.mockResolvedValue(mockResponse);
+
     mockResolve.mockReturnValue(`/tmp/file.zip`);
     mockPipeline.mockResolvedValue(undefined);
 
@@ -97,6 +106,7 @@ describe(`downloadFile`, () => {
     };
 
     mockFetch.mockResolvedValue(mockResponse);
+
     mockResolve.mockReturnValue(`/tmp/file.zip`);
     mockPipeline.mockResolvedValue(undefined);
 
@@ -133,5 +143,30 @@ describe(`downloadFile`, () => {
     await expect(downloadFile(url)).rejects.toThrow(
       `No filename in content-disposition`,
     );
+  });
+
+  it(`should sanitize filename to prevent path traversal`, async () => {
+    const url = `http://example.com/evil.zip`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename="../../../etc/passwd"`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    // Let mockResolve just echo its inputs so we can verify the arguments
+    mockResolve.mockImplementation((d: string, f: string) => `${d}/${f}`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    const destination = await downloadFile(url, `/tmp`);
+
+    const mockBasename = path.basename as unknown as jest.Mock;
+    expect(mockBasename).toHaveBeenCalledWith(`../../../etc/passwd`);
+    expect(mockResolve).toHaveBeenCalledWith(`/tmp`, `passwd`);
+    expect(destination).toBe(`/tmp/passwd`);
   });
 });

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,11 +36,20 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
-    .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+  const contentDisposition = response.headers.get(CONTENT_DISPOSITION_KEY);
+  let fileName: string | undefined;
 
-  if (fileName == null) {
+  if (contentDisposition != null) {
+    const match = contentDisposition.match(
+      /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i,
+    );
+    if (match?.[1] != null && match[1] !== ``) {
+      const rawFileName = match[1].replace(/^(['"])(.*)\1$/, `$2`).trim();
+      fileName = path.basename(rawFileName);
+    }
+  }
+
+  if (fileName == null || fileName === ``) {
     throw new Error(`No filename in content-disposition`);
   }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `downloadFile` uses unsanitized filename from `Content-Disposition` header, leading to path traversal.
🎯 Impact: A malicious server could write downloaded files outside the intended directory.
🔧 Fix: Sanitized the filename using robust regex extraction and `path.basename()`.
✅ Verification: Tests run successfully, verified path traversal attack strings are normalized.

---
*PR created automatically by Jules for task [16868165330373728766](https://jules.google.com/task/16868165330373728766) started by @ll1r1k-1337*