### PR TITLE
⚡ Bolt: Optimize stderr parsing in NatsServer

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-03-14 - Optimize NATS server stderr parsing
+**Learning:** In NatsServer, the child process stderr stream continuously emitted log chunks that were `.toString()`'d on every chunk just to check for a start condition ("Server is ready"). This causes excessive string allocations for long-running processes.
+**Action:** Use an `isReady` state flag to immediately early-return from the `data` listener and bypass expensive operations completely once the state is reached. Before state is reached, check `Buffer.isBuffer(data)` and use `.includes()` directly on the binary buffer instead of converting every chunk to a string.

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -78,20 +78,38 @@ export class NatsServer {
         reject(err);
       });
 
+      let isReady = false;
       this.process.stderr.on(`data`, (data: unknown) => {
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        const dataStr = data?.toString();
-
-        if (verbose && dataStr != null) {
-          logger.log(dataStr);
+        // ⚡ Bolt: bypass expensive operations entirely once the desired state is reached
+        if (isReady && !verbose) {
+          return;
         }
 
-        if (dataStr?.includes(`Server is ready`) === true) {
-          if (verbose) {
-            logger.log(`NATS server is ready!`);
+        let dataStr: string | undefined;
+        if (verbose) {
+          // eslint-disable-next-line @typescript-eslint/no-base-to-string
+          dataStr = data?.toString();
+          if (dataStr != null) {
+            logger.log(dataStr);
           }
-          resolve(this);
-          this.process?.unref();
+        }
+
+        if (!isReady) {
+          // ⚡ Bolt: check Buffer.isBuffer(data) and use data.includes() on binary chunks
+          // instead of calling .toString() on every chunk to avoid runtime errors and expensive allocations.
+          const hasReadyMsg =
+            dataStr != null
+              ? dataStr.includes(`Server is ready`)
+              : Buffer.isBuffer(data) && data.includes(`Server is ready`);
+
+          if (hasReadyMsg) {
+            isReady = true;
+            if (verbose) {
+              logger.log(`NATS server is ready!`);
+            }
+            resolve(this);
+            this.process?.unref();
+          }
         }
       });
 


### PR DESCRIPTION
💡 What: Optimized the parsing of the NATS server's stderr output stream. Uses an `isReady` early return to bypass all chunk processing (when `verbose` is false) after the server starts, and leverages `Buffer.isBuffer()` with `.includes()` to avoid expensive `.toString()` allocations on binary chunks.
🎯 Why: The previous implementation performed a costly `.toString()` conversion on every single stderr chunk for the entire lifetime of the process, even after the start condition was already met. High-volume log streams can cause significant CPU and memory allocation overhead.
📊 Impact: Eliminates O(N) `.toString()` calls (where N is the number of stderr chunks emitted over the server's lifetime when `verbose` is false), reducing main-thread CPU usage and GC pressure during heavy load testing or long-running NATS server mocking.
🔬 Measurement: Profiling string allocations during NATS stream processing will show a near-zero allocation footprint for `stderr` chunks once the server starts.

---
*PR created automatically by Jules for task [14347592063924242163](https://jules.google.com/task/14347592063924242163) started by @ll1r1k-1337*