### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-15 - Path Traversal in File Download
+**Vulnerability:** The downloaded file name is extracted from the `Content-Disposition` header without sanitization, allowing path traversal (e.g., `../../../etc/passwd`) which writes files outside the target directory.
+**Learning:** Even internal headers from fetch requests can be unsafe if the origin is unverified or hijacked. Path validation is essential at the boundary.
+**Prevention:** Always extract safely using robust regex and strictly apply `path.basename` to user or server-provided filenames before `path.resolve`.

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,9 +14,45 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
+
+  beforeAll(() => {
+    mockBasename.mockImplementation(
+      (p: string) => p.split(`/`).pop()?.split(`\\`).pop() ?? p,
+    );
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it(`should prevent path traversal vulnerabilities in filename`, async () => {
+    const url = `http://example.com/file.zip`;
+    const dir = `/tmp`;
+    const destination = `/tmp/passwd`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename="../../../etc/passwd"`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockResolve.mockReturnValue(destination);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    const result = await downloadFile(url, dir);
+
+    expect(result).toBe(destination);
+    expect(mockFetch).toHaveBeenCalledWith(url, {});
+    expect(mockBasename).toHaveBeenCalledWith(`../../../etc/passwd`);
+    expect(mockResolve).toHaveBeenCalledWith(dir, `passwd`);
+    expect(mockCreateWriteStream).toHaveBeenCalledWith(destination);
+    expect(mockPipeline).toHaveBeenCalledWith(`mockBody`, `mockWriteStream`);
   });
 
   it(`should download a file successfully`, async () => {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,13 +36,18 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
-    .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+  const contentDisposition = response.headers.get(CONTENT_DISPOSITION_KEY);
+  const match = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i.exec(
+    contentDisposition ?? ``,
+  );
+  let fileName = match?.[1];
 
   if (fileName == null) {
     throw new Error(`No filename in content-disposition`);
   }
+
+  fileName = fileName.replace(/^(['"])(.*)\1$/, `$2`).trim();
+  fileName = path.basename(fileName);
 
   const destination = path.resolve(dir, fileName);
   const fileStream = createWriteStream(destination);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `downloadFile` function unsafely extracted the target filename from the `Content-Disposition` header. An attacker could serve a malicious filename like `../../../etc/passwd` leading to path traversal.
🎯 Impact: Arbitrary file write and possible remote code execution (RCE) if an attacker can control the downloaded file origin, compromising the host filesystem.
🔧 Fix: Used `path.basename()` to strip directory components from the extracted filename and improved header parsing.
✅ Verification: Covered by the new `should prevent path traversal vulnerabilities in filename` test.

---
*PR created automatically by Jules for task [13338719937665668461](https://jules.google.com/task/13338719937665668461) started by @ll1r1k-1337*