### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-16 - Prevent Path Traversal in File Download
+**Vulnerability:** The `downloadFile` utility extracted the filename directly from the `Content-Disposition` header without sanitization, leading to a potential path traversal vulnerability if a malicious server returned a filename like `../../../etc/passwd`.
+**Learning:** Even when interacting with external services, filenames provided in headers (`Content-Disposition`) must be treated as untrusted user input, as the remote server could be compromised or malicious.
+**Prevention:** Always sanitize filenames extracted from HTTP headers using `path.basename()` to strip directory components and ensure they are safely resolved within the intended target directory.

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,9 +14,13 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockBasename.mockImplementation(
+      (p: string) => p.split(`/`).pop()?.split(`\\`).pop() ?? p,
+    );
   });
 
   it(`should download a file successfully`, async () => {
@@ -133,5 +137,53 @@ describe(`downloadFile`, () => {
     await expect(downloadFile(url)).rejects.toThrow(
       `No filename in content-disposition`,
     );
+  });
+
+  it(`should prevent path traversal attacks`, async () => {
+    const url = `http://example.com/file.zip`;
+    const dir = `/tmp`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename="../../etc/passwd"`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockResolve.mockReturnValue(`/tmp/passwd`);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    await downloadFile(url, dir);
+
+    expect(mockBasename).toHaveBeenCalledWith(`../../etc/passwd`);
+    expect(mockResolve).toHaveBeenCalledWith(dir, `passwd`);
+  });
+
+  it(`should correctly extract quoted filenames`, async () => {
+    const url = `http://example.com/file.zip`;
+    const dir = `/tmp`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename="file with spaces.zip"`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockResolve.mockReturnValue(`/tmp/file with spaces.zip`);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    await downloadFile(url, dir);
+
+    expect(mockBasename).toHaveBeenCalledWith(`file with spaces.zip`);
+    expect(mockResolve).toHaveBeenCalledWith(dir, `file with spaces.zip`);
   });
 });

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,11 +36,20 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
-    .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+  const contentDisposition = response.headers.get(CONTENT_DISPOSITION_KEY);
+  let fileName = null;
 
-  if (fileName == null) {
+  const match =
+    contentDisposition != null
+      ? /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i.exec(contentDisposition)
+      : null;
+
+  if (match?.[1] != null) {
+    fileName = match[1].replace(/^(['"])(.*)\1$/, `$2`).trim();
+    fileName = path.basename(fileName);
+  }
+
+  if (fileName == null || fileName === ``) {
     throw new Error(`No filename in content-disposition`);
   }
 


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Path traversal vulnerability in `downloadFile` utility when extracting the filename from the `Content-Disposition` header. An attacker-controlled server could respond with malicious filenames like `../../etc/passwd`.
🎯 **Impact**: Allowed the utility to write the downloaded file to arbitrary directories outside the intended destination directory on the local system.
🔧 **Fix**: Implemented robust regex parsing to handle quoted and unquoted filenames and strictly sanitized the extracted filename using `path.basename` to strip directory traversal components.
✅ **Verification**: Run `npm test` to see tests explicitly checking that path traversal components (e.g. `../../etc/passwd`) evaluate strictly to the file's base name (`passwd`).

---
*PR created automatically by Jules for task [2984379229790572590](https://jules.google.com/task/2984379229790572590) started by @ll1r1k-1337*