### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in file download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-18 - Path Traversal Vulnerability in `downloadFile`
+**Vulnerability:** The `downloadFile` function in `src/utils/download-file.ts` constructs a file destination using `path.resolve(dir, fileName)`, where `fileName` is extracted directly from the `Content-Disposition` HTTP header without sanitization. An attacker controlling the URL response can include directory traversal sequences (e.g., `filename="../../../etc/passwd"`) to overwrite arbitrary files on the system running the server.
+**Learning:** Parsing HTTP headers, particularly `Content-Disposition`, for filenames requires robust sanitization because the values are untrusted external input.
+**Prevention:** Always use `path.basename()` to strip directory components from untrusted filenames before resolving them against a target directory.

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,9 +14,13 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockBasename.mockImplementation(
+      (p: string) => p.split(`/`).pop()?.split(`\\`).pop() ?? p,
+    );
   });
 
   it(`should download a file successfully`, async () => {
@@ -41,6 +45,34 @@ describe(`downloadFile`, () => {
     expect(result).toBe(destination);
     expect(mockFetch).toHaveBeenCalledWith(url, {});
     expect(mockResolve).toHaveBeenCalledWith(dir, `file.zip`);
+    expect(mockCreateWriteStream).toHaveBeenCalledWith(destination);
+    expect(mockPipeline).toHaveBeenCalledWith(`mockBody`, `mockWriteStream`);
+  });
+
+  it(`should sanitize filename to prevent path traversal`, async () => {
+    const url = `http://example.com/file.zip`;
+    const dir = `/tmp`;
+    const destination = `/tmp/passwd`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename="../../../etc/passwd"`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockResolve.mockReturnValue(destination);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    const result = await downloadFile(url, dir);
+
+    expect(result).toBe(destination);
+    expect(mockFetch).toHaveBeenCalledWith(url, {});
+    expect(mockResolve).toHaveBeenCalledWith(dir, `passwd`);
     expect(mockCreateWriteStream).toHaveBeenCalledWith(destination);
     expect(mockPipeline).toHaveBeenCalledWith(`mockBody`, `mockWriteStream`);
   });

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,13 +36,19 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
-    .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+  const contentDisposition = response.headers.get(CONTENT_DISPOSITION_KEY);
+  const match = contentDisposition?.match(
+    /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i,
+  );
+  let fileName = match?.[1];
 
   if (fileName == null) {
     throw new Error(`No filename in content-disposition`);
   }
+
+  fileName = fileName.replace(/^(['"])(.*)\1$/, `$2`).trim();
+  // SECURITY: Prevent path traversal by extracting only the base file name
+  fileName = path.basename(fileName);
 
   const destination = path.resolve(dir, fileName);
   const fileStream = createWriteStream(destination);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Path Traversal
🎯 Impact: An attacker controlling the remote server from which a file is downloaded could manipulate the Content-Disposition header (e.g., `filename="../../../etc/passwd"`) to overwrite arbitrary files on the local file system.
🔧 Fix: The file name extracted from the Content-Disposition header is now stripped of quotes and sanitized using `path.basename()` to safely isolate the base file name and discard any directory traversal segments.
✅ Verification: Run `npm test` and note the added test case verifying that `../../../etc/passwd` correctly yields just `passwd`.

---
*PR created automatically by Jules for task [7484409320676912970](https://jules.google.com/task/7484409320676912970) started by @ll1r1k-1337*