### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-19 - Fix Path Traversal in downloadFile
+**Vulnerability:** Extracting filenames from Content-Disposition headers using a simple string split allows malicious servers to provide filenames containing path traversal characters (e.g., `../../file.txt`), which could result in writing files outside the intended download directory.
+**Learning:** Parsing HTTP headers for filenames requires robust regex to handle both quoted and unquoted values, followed by applying `path.basename()` to strip any directory components provided by the server before resolving the destination path.
+**Prevention:** Always use `path.basename()` on user-provided or externally-sourced filenames before joining them with a trusted base directory to ensure cross-platform safety against path traversal attacks.

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,8 +14,12 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
+    mockBasename.mockImplementation(
+      (p) => p.split(`/`).pop()?.split(`\\`).pop() ?? p,
+    );
     jest.clearAllMocks();
   });
 
@@ -117,6 +121,26 @@ describe(`downloadFile`, () => {
     await expect(downloadFile(url)).rejects.toThrow(
       `Failed to download http://example.com/file.zip: Not Found`,
     );
+  });
+
+  it(`should strip path traversal from filename`, async () => {
+    const url = `http://example.com/file.zip`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest.fn().mockReturnValue(`attachment; filename=../../secret.txt`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockResolve.mockReturnValue(`/tmp/secret.txt`);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    await downloadFile(url, `/tmp`);
+
+    expect(mockResolve).toHaveBeenCalledWith(`/tmp`, `secret.txt`);
   });
 
   it(`should throw error if filename is missing`, async () => {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,13 +36,16 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
+  let fileName = response.headers
     .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+    ?.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i)?.[1];
 
   if (fileName == null) {
     throw new Error(`No filename in content-disposition`);
   }
+
+  fileName = fileName.replace(/^(['"])(.*)\1$/, `$2`).trim();
+  fileName = path.basename(fileName);
 
   const destination = path.resolve(dir, fileName);
   const fileStream = createWriteStream(destination);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `downloadFile` function blindly extracts filenames from the `Content-Disposition` header by splitting strings and uses it to construct a local file path. A malicious server could supply a filename with path traversal characters (like `../../`), causing files to be overwritten or created anywhere on the local filesystem.
🎯 Impact: Remote code execution or data overwrite. By serving a crafted filename, a malicious server can escape the intended `downloadDir` and write arbitrary files to the user's filesystem.
🔧 Fix: Updated the header parsing to extract filenames robustly with regex, removed surrounding quotes, and applied `path.basename()` to eliminate any directory traversal components, ensuring files are strictly written to the expected directory.
✅ Verification: Ran the test suite which now includes explicit tests verifying path traversal elements (`../../secret.txt`) are correctly stripped down to the safe basename (`secret.txt`).

---
*PR created automatically by Jules for task [9093611062635665716](https://jules.google.com/task/9093611062635665716) started by @ll1r1k-1337*