### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in downloadFile

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-20 - Prevent Path Traversal in Download Filename
+**Vulnerability:** The `downloadFile` function trusted the `filename` parameter from the `Content-Disposition` HTTP header, passing it directly to `path.resolve()`. This allowed a malicious server to perform a path traversal attack.
+**Learning:** Always treat user/server-provided input, especially filenames from HTTP headers, as untrusted.
+**Prevention:** Use `path.basename()` (with backslash sanitization) to extract only the final file component, stripping any directory path segments, before using it in file system operations.

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,6 +14,9 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  (path.basename as unknown as jest.Mock).mockImplementation(
+    (p: string) => p.split(`/`).pop()?.split(`\\`).pop() ?? p,
+  );
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -133,5 +136,28 @@ describe(`downloadFile`, () => {
     await expect(downloadFile(url)).rejects.toThrow(
       `No filename in content-disposition`,
     );
+  });
+
+  it(`should sanitize filename to prevent path traversal`, async () => {
+    const url = `http://example.com/file.zip`;
+    const dir = `/tmp`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename=../../../../malicious.txt`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockResolve.mockReturnValue(`/tmp/malicious.txt`);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    await downloadFile(url, dir);
+
+    expect(mockResolve).toHaveBeenCalledWith(dir, `malicious.txt`);
   });
 });

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,13 +36,19 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
-    .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+  const contentDisposition = response.headers.get(CONTENT_DISPOSITION_KEY);
+  const match = contentDisposition?.match(
+    /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i,
+  );
+  let fileName = match?.[1];
 
   if (fileName == null) {
     throw new Error(`No filename in content-disposition`);
   }
+
+  // Sanitize to prevent path traversal
+  fileName = fileName.replace(/^(['"])(.*)\1$/, `$2`).trim();
+  fileName = path.basename(fileName.replace(/\\/g, `/`));
 
   const destination = path.resolve(dir, fileName);
   const fileStream = createWriteStream(destination);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `downloadFile` utility trusted the `filename` parameter from the `Content-Disposition` HTTP header, passing it directly to `path.resolve()`. This allowed a malicious server to provide a filename like `../../../../etc/passwd` or `../../../../tmp/malicious.txt` to execute a path traversal attack and write files anywhere on the system.
🎯 Impact: Arbitrary file write/overwrite on the system running the server builder.
🔧 Fix: Added robust regex parsing and `path.basename()` to sanitize the filename extracted from the header, stripping any path segments and ensuring the file is safely written inside the target directory.
✅ Verification: Unit tests have been updated and verified to handle and reject path traversal attempts.

---
*PR created automatically by Jules for task [7620197129454464761](https://jules.google.com/task/7620197129454464761) started by @ll1r1k-1337*