### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-21 - Path Traversal in File Download
+**Vulnerability:** Extracted filename from `Content-Disposition` header was directly passed to `path.resolve` without sanitization, allowing path traversal (e.g. `../../../etc/passwd`).
+**Learning:** Never trust filenames from remote servers. Simple string splitting is insufficient to extract filenames securely, and `path.resolve` will evaluate relative path components from user input.
+**Prevention:** Use robust regex to extract filenames handling quotes, and explicitly sanitize against path traversal using `path.basename()` combined with cross-platform slash normalization (`.replace(/\\/g, '/')`).

--- a/src/utils/download-file.security.spec.ts
+++ b/src/utils/download-file.security.spec.ts
@@ -1,0 +1,71 @@
+import { downloadFile } from './download-file';
+import fetch from 'make-fetch-happen';
+import fs from 'fs';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+
+jest.mock(`make-fetch-happen`);
+jest.mock(`fs`);
+jest.mock(`stream/promises`);
+
+describe(`downloadFile security`, () => {
+  const mockFetch = fetch as unknown as jest.Mock;
+  const mockPipeline = pipeline as unknown as jest.Mock;
+  const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`should sanitize Path Traversal in Content-Disposition`, async () => {
+    const url = `http://example.com/malicious.zip`;
+    const dir = `/safe/dir`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename=../../../etc/passwd`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    const result = await downloadFile(url, dir);
+
+    // It should have resolved the sanitized filename 'passwd' against '/safe/dir'
+    const expectedDest = path.resolve(dir, `passwd`);
+    expect(result).toBe(expectedDest);
+    expect(mockCreateWriteStream).toHaveBeenCalledWith(expectedDest);
+  });
+
+  it(`should sanitize Windows Path Traversal in Content-Disposition`, async () => {
+    const url = `http://example.com/malicious2.zip`;
+    const dir = `/safe/dir`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(
+            `attachment; filename="..\\..\\..\\windows\\system32\\cmd.exe"`,
+          ),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    const result = await downloadFile(url, dir);
+
+    // It should have resolved the sanitized filename 'cmd.exe' against '/safe/dir'
+    const expectedDest = path.resolve(dir, `cmd.exe`);
+    expect(result).toBe(expectedDest);
+    expect(mockCreateWriteStream).toHaveBeenCalledWith(expectedDest);
+  });
+});

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,8 +14,12 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
+    mockBasename.mockImplementation(
+      (p) => p.split(`/`).pop()?.split(`\\`).pop() ?? p,
+    );
     jest.clearAllMocks();
   });
 

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,9 +36,18 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
-    .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+  const contentDisposition = response.headers.get(CONTENT_DISPOSITION_KEY);
+  const match = contentDisposition?.match(
+    /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i,
+  );
+  const rawFileName = match?.[1]?.replace(/^(['"])(.*)\1$/, `$2`).trim();
+
+  // 🛡️ Sentinel: Sanitize against Path Traversal by extracting only the basename
+  // and normalizing backslashes to handle cross-platform attacks (e.g. Windows paths on Linux)
+  const fileName =
+    rawFileName != null && rawFileName !== ``
+      ? path.basename(rawFileName.replace(/\\/g, `/`))
+      : undefined;
 
   if (fileName == null) {
     throw new Error(`No filename in content-disposition`);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `downloadFile` utility directly extracted filenames from the `Content-Disposition` header by splitting at `filename=` and passed this untrusted input directly to `path.resolve()`. This allowed malicious servers to respond with payloads like `../../../etc/passwd` to overwrite arbitrary files outside the target directory (Path Traversal).
🎯 Impact: Remote code execution or unauthorized file overwrite if an application downloads files from untrusted endpoints using this utility.
🔧 Fix:
- Changed extraction logic to use a robust regular expression that properly captures and strips quotes.
- Added explicit path sanitization using `path.basename()` combined with cross-platform slash normalization to ensure only the base filename is used, preventing traversal via `../` or `..\`.
✅ Verification:
- Added `download-file.security.spec.ts` with explicit regression tests against both Unix and Windows path traversal payloads.
- Ensured existing tests pass.
- Verified using `npm run lint`, `npm run test`, and `npm run format`.

---
*PR created automatically by Jules for task [3525549245155395263](https://jules.google.com/task/3525549245155395263) started by @ll1r1k-1337*