### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in File Download

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-22 - Path Traversal in File Download
+**Vulnerability:** The application was extracting filenames from the `Content-Disposition` header using a simple split without sanitization. An attacker could use a server returning `filename="../../../evil.sh"` to perform path traversal when `path.resolve` was called, potentially writing files to arbitrary locations on disk.
+**Learning:** `path.resolve()` combines paths but does not restrict them to a specific base directory. Extracting filenames from untrusted input requires strict sanitization. Relying solely on `path.basename` may also fail on POSIX systems if the path uses backslashes (e.g., `..\..\evil.sh`).
+**Prevention:** Always sanitize untrusted filenames by replacing backslashes with forward slashes and using `path.basename()` before resolving the path. Additionally, use robust regex patterns when extracting fields from HTTP headers.

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,8 +14,12 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
+    mockBasename.mockImplementation(
+      (p: string) => p.split(`/`).pop()?.split(`\\`).pop() ?? p,
+    );
     jest.clearAllMocks();
   });
 
@@ -117,6 +121,29 @@ describe(`downloadFile`, () => {
     await expect(downloadFile(url)).rejects.toThrow(
       `Failed to download http://example.com/file.zip: Not Found`,
     );
+  });
+
+  it(`should prevent path traversal in filename`, async () => {
+    const url = `http://example.com/file.zip`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename="../../../evil.sh"`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockResolve.mockReturnValue(`/tmp/evil.sh`);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    await downloadFile(url, `/tmp`);
+
+    expect(mockBasename).toHaveBeenCalledWith(`../../../evil.sh`);
+    expect(mockResolve).toHaveBeenCalledWith(`/tmp`, `evil.sh`);
   });
 
   it(`should throw error if filename is missing`, async () => {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,9 +36,20 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
-    .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+  const contentDisposition = response.headers.get(CONTENT_DISPOSITION_KEY);
+  let fileName: string | undefined;
+
+  if (contentDisposition != null) {
+    const match = contentDisposition.match(
+      /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i,
+    );
+    if (match?.[1] !== undefined && match[1] !== ``) {
+      // Remove quotes and extract basename to prevent path traversal
+      const cleanFileName = match[1].replace(/^(['"])(.*)\1$/, `$2`).trim();
+      // Replace backslashes with forward slashes for cross-platform safety
+      fileName = path.basename(cleanFileName.replace(/\\/g, `/`));
+    }
+  }
 
   if (fileName == null) {
     throw new Error(`No filename in content-disposition`);


### PR DESCRIPTION
- 🚨 Severity: CRITICAL
- 💡 Vulnerability: `downloadFile` trusted filenames in the `Content-Disposition` header without sanitization, leading to a path traversal vulnerability.
- 🎯 Impact: A malicious server could return a path-traversing filename like `../../../evil.sh`, causing the client to write files to arbitrary locations outside the intended download directory.
- 🔧 Fix: Implemented robust extraction of the filename using regex, removed quotes, normalized slashes, and applied `path.basename` to extract only the safe file name. Added a unit test to verify path traversal is thwarted.
- ✅ Verification: Run `npm run lint` and `npm test`. The new test `should prevent path traversal in filename` verifies the fix.

---
*PR created automatically by Jules for task [15552062384762118331](https://jules.google.com/task/15552062384762118331) started by @ll1r1k-1337*