### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary file write via path traversal in download utility

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-23 - Arbitrary File Write via Path Traversal in File Download
+**Vulnerability:** Directly using the `filename` from a `Content-Disposition` HTTP header in file download scripts allows a malicious server to specify directory traversal paths like `../../foo.txt` and drop arbitrary files anywhere on the system.
+**Learning:** External or untrusted servers can send malicious metadata in headers (like `Content-Disposition`) to overwrite sensitive files.
+**Prevention:** Always sanitize filenames from untrusted sources by extracting only the base name (e.g., using `path.basename()` after replacing backslashes) before resolving the download destination path.

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -18,7 +18,9 @@ describe(`downloadFile`, () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockBasename.mockImplementation((p) => p.split(`/`).pop()?.split(`\\`).pop() ?? p);
+    mockBasename.mockImplementation(
+      (p) => p.split(`/`).pop()?.split(`\\`).pop() ?? p,
+    );
   });
 
   it(`should download a file successfully`, async () => {

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,9 +14,11 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockBasename.mockImplementation((p) => p.split(`/`).pop()?.split(`\\`).pop() ?? p);
   });
 
   it(`should download a file successfully`, async () => {

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,11 +36,20 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
-    .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+  const contentDisposition = response.headers.get(CONTENT_DISPOSITION_KEY);
+  let fileName: string | undefined;
 
-  if (fileName == null) {
+  if (contentDisposition != null) {
+    const match = contentDisposition.match(
+      /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i,
+    );
+    if (match?.[1] != null) {
+      fileName = match[1].replace(/^(['"])(.*)\1$/, `$2`).trim();
+      fileName = path.basename(fileName.replace(/\\/g, `/`));
+    }
+  }
+
+  if (fileName == null || fileName === ``) {
     throw new Error(`No filename in content-disposition`);
   }
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `downloadFile` utility extracts the filename directly from the `Content-Disposition` header and passes it to `path.resolve` without sanitization.
🎯 Impact: High impact, as an attacker controlling the HTTP response could send a filename like `../../../../../etc/passwd` to overwrite arbitrary files on the user's system, leading to code execution or privilege escalation.
🔧 Fix: Implemented robust `Content-Disposition` parsing to extract the filename cleanly and applied `path.basename(fileName.replace(/\\/g, '/'))` to explicitly prevent path traversal.
✅ Verification: Run `npm test` and `npm run lint` to verify that normal file downloads continue to function, and unit tests pass.

---
*PR created automatically by Jules for task [16705164147633943863](https://jules.google.com/task/16705164147633943863) started by @ll1r1k-1337*