### PR TITLE
⚡ Bolt: Optimize NatsServer stderr processing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-24 - NatsServer stderr string conversion bottleneck
+**Learning:** For high-volume log streams like `stderr` in `NatsServer`, calling `toString()` on every binary chunk causes expensive runtime allocations.
+**Action:** Use state flags (like `isReady`) and check `Buffer.isBuffer(data)` to use `data.includes('Server is ready')` on binary chunks instead of calling `.toString()` on every chunk, and use early returns to bypass expensive operations entirely once the desired state is reached.

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -78,20 +78,32 @@ export class NatsServer {
         reject(err);
       });
 
+      let isReady = false;
       this.process.stderr.on(`data`, (data: unknown) => {
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        const dataStr = data?.toString();
+        // ⚡ Bolt: Optimize by skipping processing if already ready and not verbose
+        if (isReady && !verbose) return;
 
-        if (verbose && dataStr != null) {
-          logger.log(dataStr);
+        // ⚡ Bolt: Check for ready state using Buffer.includes to avoid expensive string allocation
+        if (!isReady) {
+          const isReadyNow = Buffer.isBuffer(data)
+            ? data.includes(`Server is ready`)
+            : // eslint-disable-next-line @typescript-eslint/no-base-to-string
+              data?.toString().includes(`Server is ready`);
+
+          if (isReadyNow === true) {
+            isReady = true;
+            if (verbose) {
+              logger.log(`NATS server is ready!`);
+            }
+            resolve(this);
+            this.process?.unref();
+          }
         }
 
-        if (dataStr?.includes(`Server is ready`) === true) {
-          if (verbose) {
-            logger.log(`NATS server is ready!`);
-          }
-          resolve(this);
-          this.process?.unref();
+        // ⚡ Bolt: Only convert to string if verbose logging is enabled
+        if (verbose && data != null) {
+          // eslint-disable-next-line @typescript-eslint/no-base-to-string
+          logger.log(data.toString());
         }
       });
 

--- a/test-buffer.js
+++ b/test-buffer.js
@@ -1,0 +1,2 @@
+const buf = Buffer.from('Server is ready to roll');
+console.log(buf.includes('Server is ready'));


### PR DESCRIPTION
💡 What: Optimize `stderr` data processing in `NatsServer` by using `Buffer.includes` and adding an early return flag (`isReady`).
🎯 Why: Calling `.toString()` on every binary chunk from high-volume log streams causes unnecessary and expensive runtime allocations, especially once the server is already ready.
📊 Impact: Reduces string allocations and CPU cycles during server operation, improving performance by avoiding expensive string conversions for every incoming stderr chunk.
🔬 Measurement: Verify by running the test suite and ensuring all tests pass, confirming the server still starts and stops successfully while handling output efficiently.

---
*PR created automatically by Jules for task [3388455582831980474](https://jules.google.com/task/3388455582831980474) started by @ll1r1k-1337*