### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Content-Disposition

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-03-25 - Prevent Path Traversal via Content-Disposition
+**Vulnerability:** The application extracted filenames directly from the `content-disposition` HTTP header without sanitization, leading to a path traversal vulnerability. An attacker could potentially supply a malicious filename (e.g., `../../../etc/passwd`), forcing the application to write files to arbitrary directories on the host.
+**Learning:** HTTP headers such as `content-disposition` must always be treated as untrusted user input, even if the destination URL appears safe, because the underlying server could be compromised or manipulated to return a malicious payload.
+**Prevention:** Always extract filenames using robust regex to handle quoting properly, and pass the parsed filename through `path.basename()` (after standardizing slashes with `.replace(/\\/g, '/')`) to eliminate all directory traversal attempts before saving to the filesystem.

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -14,6 +14,13 @@ describe(`downloadFile`, () => {
   const mockPipeline = pipeline as unknown as jest.Mock;
   const mockCreateWriteStream = fs.createWriteStream as unknown as jest.Mock;
   const mockResolve = path.resolve as unknown as jest.Mock;
+  const mockBasename = path.basename as unknown as jest.Mock;
+
+  beforeAll(() => {
+    mockBasename.mockImplementation(
+      (p: string) => p.split(`/`).pop()?.split(`\\`).pop() ?? p,
+    );
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -133,5 +140,28 @@ describe(`downloadFile`, () => {
     await expect(downloadFile(url)).rejects.toThrow(
       `No filename in content-disposition`,
     );
+  });
+
+  it(`should prevent path traversal when filename contains directory components`, async () => {
+    const url = `http://example.com/file.zip`;
+    const dir = `/tmp`;
+    const mockResponse = {
+      ok: true,
+      headers: {
+        get: jest
+          .fn()
+          .mockReturnValue(`attachment; filename="../../etc/passwd"`),
+      },
+      body: `mockBody`,
+    };
+
+    mockFetch.mockResolvedValue(mockResponse);
+    mockResolve.mockReturnValue(`/tmp/passwd`);
+    mockCreateWriteStream.mockReturnValue(`mockWriteStream`);
+    mockPipeline.mockResolvedValue(undefined);
+
+    await downloadFile(url, dir);
+
+    expect(mockResolve).toHaveBeenCalledWith(dir, `passwd`);
   });
 });

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -36,15 +36,19 @@ export async function downloadFile(
     throw new Error(`Failed to download ${url}: ${response.statusText}`);
   }
 
-  const fileName = response.headers
+  let fileName = response.headers
     .get(CONTENT_DISPOSITION_KEY)
-    ?.split(`filename=`)?.[1];
+    ?.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/i)?.[1];
 
   if (fileName == null) {
     throw new Error(`No filename in content-disposition`);
   }
 
-  const destination = path.resolve(dir, fileName);
+  fileName = fileName.replace(/^(['"])(.*)\1$/, `$2`).trim();
+  // Prevent Path Traversal by removing directory components
+  const safeFileName = path.basename(fileName.replace(/\\/g, `/`));
+
+  const destination = path.resolve(dir, safeFileName);
   const fileStream = createWriteStream(destination);
 
   await pipeline(response.body, fileStream);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `downloadFile` utility directly extracts the `filename` from the `content-disposition` HTTP header without sanitizing it. This allows a potentially malicious server to inject directory traversal sequences (like `../../../etc/passwd`), allowing arbitrary file writes.
🎯 Impact: An attacker could overwrite critical system files, inject backdoors, or read arbitrary data, resulting in full system compromise.
🔧 Fix: Added robust regex parsing for the filename and implemented `path.basename(fileName.replace(/\\/g, '/'))` to safely strip any directory components before writing the file to the destination directory. Added an inline comment explaining the security fix.
✅ Verification: Ran `pnpm lint` and `pnpm test` successfully. A new unit test was added specifically to ensure that path traversal sequences (e.g., `../../etc/passwd`) are correctly truncated to just the filename component (`passwd`).

---
*PR created automatically by Jules for task [9215011135602169919](https://jules.google.com/task/9215011135602169919) started by @ll1r1k-1337*