### PR TITLE
fix: retry NATS server download/extraction on transient CI failures (#96)

### DIFF
--- a/src/scripts/download.ts
+++ b/src/scripts/download.ts
@@ -8,6 +8,7 @@ import {
   getProjectConfig,
   getProjectPath,
   getUrl,
+  withRetry,
 } from '../utils';
 
 process.nextTick(async function () {
@@ -29,16 +30,38 @@ process.nextTick(async function () {
       noProxy,
     } = config;
 
-    const filePath = await downloadFile(downloadUrl, os.tmpdir(), {
-      httpProxy,
-      httpsProxy,
-      noProxy,
-    });
+    // The download can be truncated by transient CI network issues, leaving a
+    // partial archive that fails to decompress ("end of central directory record
+    // signature not found"). Wrapping both the download and the decompress in a
+    // retry uses the decompress step itself as the integrity check: a corrupt or
+    // incomplete archive throws and triggers a fresh download.
+    await withRetry(
+      async () => {
+        // Clear any partial state left behind by a previous failed attempt
+        // before downloading and extracting again.
+        fs.rmSync(downloadDir, { recursive: true, force: true });
 
-    console.log(`Downloaded was successful`);
+        const filePath = await downloadFile(downloadUrl, os.tmpdir(), {
+          httpProxy,
+          httpsProxy,
+          noProxy,
+        });
 
-    await decompress(filePath, downloadDir, { strip: 1 });
+        console.log(`Downloaded was successful`);
 
-    console.log(`Decompress was successful sources`);
+        await decompress(filePath, downloadDir, { strip: 1 });
+
+        console.log(`Decompress was successful sources`);
+      },
+      {
+        onRetry: (error, attempt) => {
+          console.log(
+            `NATS server download/extract failed (${
+              error instanceof Error ? error.message : String(error)
+            }). Retrying (attempt ${attempt})...`,
+          );
+        },
+      },
+    );
   }
 });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from './get-url';
 export * from './get-platform';
 export * from './get-arch';
 export * from './get-project-config';
+export * from './with-retry';

--- a/src/utils/with-retry.spec.ts
+++ b/src/utils/with-retry.spec.ts
@@ -1,0 +1,88 @@
+import { withRetry } from './with-retry';
+
+describe(`withRetry`, () => {
+  it(`returns the result when the operation succeeds on the first attempt`, async () => {
+    let calls = 0;
+
+    const result = await withRetry(
+      async () => {
+        calls++;
+        return `ok`;
+      },
+      { delay: 0 },
+    );
+
+    expect(result).toBe(`ok`);
+    expect(calls).toBe(1);
+  });
+
+  it(`retries and resolves when the operation fails before succeeding`, async () => {
+    let calls = 0;
+
+    const result = await withRetry(
+      async () => {
+        calls++;
+        if (calls < 3) {
+          throw new Error(`transient failure`);
+        }
+        return `ok`;
+      },
+      { retries: 5, delay: 0 },
+    );
+
+    expect(result).toBe(`ok`);
+    expect(calls).toBe(3);
+  });
+
+  it(`throws the last error after exhausting all retries`, async () => {
+    let calls = 0;
+
+    await expect(
+      withRetry(
+        async () => {
+          calls++;
+          throw new Error(`failure ${calls}`);
+        },
+        { retries: 2, delay: 0 },
+      ),
+    ).rejects.toThrow(`failure 3`);
+
+    expect(calls).toBe(3);
+  });
+
+  it(`invokes onRetry before each retry with the error and the retry number`, async () => {
+    const onRetry = jest.fn();
+    let calls = 0;
+
+    await withRetry(
+      async () => {
+        calls++;
+        if (calls < 3) {
+          throw new Error(`boom ${calls}`);
+        }
+        return `done`;
+      },
+      { retries: 5, delay: 0, onRetry },
+    );
+
+    expect(onRetry).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenNthCalledWith(1, expect.any(Error), 1);
+    expect(onRetry).toHaveBeenNthCalledWith(2, expect.any(Error), 2);
+  });
+
+  it(`does not retry when retries is set to zero`, async () => {
+    let calls = 0;
+
+    await expect(
+      withRetry(
+        async () => {
+          calls++;
+          throw new Error(`single failure`);
+        },
+        { retries: 0, delay: 0 },
+      ),
+    ).rejects.toThrow(`single failure`);
+
+    expect(calls).toBe(1);
+  });
+});

--- a/src/utils/with-retry.ts
+++ b/src/utils/with-retry.ts
@@ -1,0 +1,38 @@
+export interface WithRetryOptions {
+  /** Number of retries after the first attempt. Total attempts = retries + 1. */
+  retries?: number;
+  /** Delay in milliseconds between attempts. */
+  delay?: number;
+  /** Called before each retry with the error and the 1-based retry number. */
+  onRetry?: (error: unknown, attempt: number) => void;
+}
+
+const DEFAULT_RETRIES = 3;
+const DEFAULT_DELAY = 1000;
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: WithRetryOptions = {},
+): Promise<T> {
+  const { retries = DEFAULT_RETRIES, delay = DEFAULT_DELAY, onRetry } = options;
+
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      if (attempt < retries) {
+        onRetry?.(error, attempt + 1);
+
+        if (delay > 0) {
+          await new Promise((resolve) => setTimeout(resolve, delay));
+        }
+      }
+    }
+  }
+
+  throw lastError;
+}


### PR DESCRIPTION
## Problem

Fixes #96.

When installing in GitHub CI, the postinstall download of the NATS server intermittently failed with:

```
Error: end of central directory record signature not found
    at .../yauzl/index.js:187:14
```

The archive downloads but can't be unzipped. It is **CI-only** (never reproduced on localhost) and **succeeds after a retry** — classic transient network truncation.

## Root cause

`src/scripts/download.ts` downloaded the zip and decompressed it with **no integrity check and no retry**. `downloadFile` uses `pipeline(response.body, fileStream)`, which can resolve on a *truncated* body when the connection drops mid-stream in CI. "Downloaded was successful" then prints on a partial file, and `decompress`/yauzl reads to the end, finds no End-Of-Central-Directory record, and throws — failing the whole install.

## Fix

Wrap **both** the download and the decompress in a retry loop, so `decompress` itself acts as the ground-truth integrity check: a corrupt or incomplete archive throws and triggers a fresh download.

- **`src/utils/with-retry.ts`** (new) — generic `withRetry(fn, { retries, delay, onRetry })` helper (default 3 retries).
- **`src/utils/with-retry.spec.ts`** (new) — unit tests (success-first-try, fail-then-succeed, exhaust-and-throw-last-error, `onRetry` callback, no-retry-when-0).
- **`src/scripts/download.ts`** — wraps `downloadFile` + `decompress` in `withRetry`, clears any partial target dir before each attempt, and logs each retry for CI visibility.
- **`src/utils/index.ts`** — exports the helper.

### Why not a Content-Length check?

Considered and rejected: it would force `compress: false` (breaking existing `download-file.spec.ts` assertions) and risk a *systematic* false mismatch on content-encoded responses. The decompress-retry covers truncation strictly better, since decompress validates the actual archive.

## Verification

- `withRetry` unit tests: written test-first (watched RED → GREEN), 5/5 pass.
- Full suite: **24/24 pass** across 4 suites.
- Lint clean (changed files); `tsc` build clean.
- Happy path: real download + decompress of the NATS binary succeeds.
- **Recovery path**: truncated the real downloaded zip → `decompress` **rejects catchably** with the issue's exact message (`end of central directory record signature not found`) — no uncaught exception — confirming `withRetry`'s `try/catch` catches it and re-downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
