### PR TITLE
docs: add Testing with Jest and License sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
 5. [Configuration](#configuration)
 6. [API Reference](#api-reference)
 7. [NATS Jetstream](#nats-jetstream)
-8. [Contributing](#contributing)
+8. [Testing with Jest](#testing-with-jest)
+9. [Contributing](#contributing)
+10. [License](#license)
 
 
 # Description
@@ -224,8 +226,39 @@ new NatsServer({
 });
 ```
 
+## Testing with Jest
+
+A common use case is spinning up a server once per test suite. Start it in
+`beforeAll` and tear it down in `afterAll`:
+
+```javascript
+const { NatsServerBuilder } = require('nats-memory-server');
+const { connect } = require('nats');
+
+let server;
+let nc;
+
+beforeAll(async () => {
+  server = await NatsServerBuilder.create().build().start();
+  nc = await connect({ servers: server.getUrl() });
+});
+
+afterAll(async () => {
+  await nc.close();
+  await server.stop();
+});
+
+test('should publish and subscribe', async () => {
+  // Your test logic here
+});
+```
+
 ## Contributing
 
 Contributions are welcome! If you find any issues or have suggestions for improvement, please feel free to open an issue or submit a pull request on the [GitHub repository](https://github.com/Llirik1337/nats-memory-server).
 
 When contributing, please ensure to follow the [code of conduct](https://github.com/Llirik1337/nats-memory-server/blob/main/CODE_OF_CONDUCT.md).
+
+## License
+
+This project is licensed under the MIT License — see the [LICENSE](https://github.com/Llirik1337/nats-memory-server/blob/main/LICENSE) file for details.


### PR DESCRIPTION
Ports the genuinely-additive sections from the stale README rewrite in #2 onto the **current** `main` README (which has since been overhauled in #3 with proxy-settings docs), instead of resolving #2's ~200-line conflict.

### What's added
- **Testing with Jest** — `beforeAll`/`afterAll` pattern for sharing one server across a test suite. `main` had no testing section.
- **License** — short MIT section linking the `LICENSE` file. `main` only had the license badge.
- Table of Contents updated.

### Intentionally omitted from #2
- **Quick Start** — `main`'s existing **Usage** section already documents the same start → pub/sub → stop flow, so a separate Quick Start would just duplicate it.
- The `package.json` devDependency churn in #2 (reordering + `ts-node`) — unrelated to docs.

Supersedes #2.