### PR TITLE
feat: verify downloaded NATS binary against published SHA256SUMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ You can configure the library using one of the following files:
   "version": "v2.9.16",
   "buildFromSource": false,
   "binPath": "node_modules/.cache/nats-memory-server/nats-server",
+  "verifyChecksum": "warn",
   "verbose": true,
   "ip": "0.0.0.0"
 }
@@ -122,6 +123,7 @@ You can configure the library using one of the following files:
 - `httpProxy`: (string) Proxy URL for HTTP requests.
 - `httpsProxy`: (string) Proxy URL for HTTPS requests.
 - `noProxy`: (string) Domain extensions to bypass the proxy.
+- `verifyChecksum`: (`'strict' | 'warn' | 'off'`) Verify the downloaded archive against the release's published `SHA256SUMS` before extracting/executing it. `warn` (default) aborts the install on a checksum **mismatch** but only warns when a checksum cannot be obtained (e.g. a custom `downloadUrl` or `buildFromSource`); `strict` also aborts when the checksum is unavailable; `off` disables the check. Default: `warn`.
 
 **Runtime Options:**
 - `port`: (number) Port to listen on. If not specified, a free port is chosen.

--- a/src/scripts/download.ts
+++ b/src/scripts/download.ts
@@ -3,11 +3,13 @@ import fs from 'fs';
 import os from 'os';
 import {
   downloadFile,
+  fetchText,
   getArch,
   getPlatform,
   getProjectConfig,
   getProjectPath,
   getUrl,
+  verifyChecksum,
   withRetry,
 } from '../utils';
 
@@ -28,6 +30,7 @@ process.nextTick(async function () {
       httpProxy,
       httpsProxy,
       noProxy,
+      verifyChecksum: verifyChecksumMode = `warn`,
     } = config;
 
     // The download can be truncated by transient CI network issues, leaving a
@@ -48,6 +51,19 @@ process.nextTick(async function () {
         });
 
         console.log(`Downloaded was successful`);
+
+        // Verify the archive against the release's published SHA256SUMS before
+        // extracting/executing it. Skipped for buildFromSource (a source
+        // tarball, not a checksummed release asset).
+        if (!buildFromSource) {
+          await verifyChecksum(
+            filePath,
+            downloadUrl,
+            verifyChecksumMode,
+            { httpProxy, httpsProxy, noProxy },
+            { fetchText, logger: console },
+          );
+        }
 
         await decompress(filePath, downloadDir, { strip: 1 });
 

--- a/src/utils/download-file.spec.ts
+++ b/src/utils/download-file.spec.ts
@@ -1,4 +1,4 @@
-import { downloadFile } from './download-file';
+import { downloadFile, fetchText } from './download-file';
 import fetch from 'make-fetch-happen';
 import fs from 'fs';
 import path from 'path';
@@ -183,5 +183,51 @@ describe(`downloadFile`, () => {
       `No filename in content-disposition`,
     );
     expect(mockCreateWriteStream).not.toHaveBeenCalled();
+  });
+});
+
+describe(`fetchText`, () => {
+  const mockFetch = fetch as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it(`returns the response body text`, async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(`hash  asset.zip`),
+    });
+
+    const result = await fetchText(`https://example.com/SHA256SUMS`);
+
+    expect(result).toBe(`hash  asset.zip`);
+    expect(mockFetch).toHaveBeenCalledWith(
+      `https://example.com/SHA256SUMS`,
+      {},
+    );
+  });
+
+  it(`passes the https proxy for an https target`, async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(`x`),
+    });
+
+    await fetchText(`https://example.com/SHA256SUMS`, {
+      httpsProxy: `http://proxy.com`,
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(`https://example.com/SHA256SUMS`, {
+      proxy: `http://proxy.com`,
+    });
+  });
+
+  it(`throws when the response is not ok`, async () => {
+    mockFetch.mockResolvedValue({ ok: false, statusText: `Not Found` });
+
+    await expect(fetchText(`https://example.com/SHA256SUMS`)).rejects.toThrow(
+      `Failed to fetch https://example.com/SHA256SUMS: Not Found`,
+    );
   });
 });

--- a/src/utils/download-file.ts
+++ b/src/utils/download-file.ts
@@ -11,11 +11,8 @@ export interface DownloadFileOptions {
   noProxy?: string;
 }
 
-export async function downloadFile(
-  url: string,
-  dir = `./`,
-  options: DownloadFileOptions = {},
-): Promise<string> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function buildFetchOptions(url: string, options: DownloadFileOptions): any {
   const proxy = url.startsWith(`https:`)
     ? options.httpsProxy
     : options.httpProxy;
@@ -30,7 +27,30 @@ export async function downloadFile(
     fetchOptions.noProxy = options.noProxy;
   }
 
-  const response = await fetch(url, fetchOptions);
+  return fetchOptions;
+}
+
+/** Fetches a small text resource (e.g. a SHA256SUMS file) with the same proxy
+ * handling as {@link downloadFile}. */
+export async function fetchText(
+  url: string,
+  options: DownloadFileOptions = {},
+): Promise<string> {
+  const response = await fetch(url, buildFetchOptions(url, options));
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: ${response.statusText}`);
+  }
+
+  return await response.text();
+}
+
+export async function downloadFile(
+  url: string,
+  dir = `./`,
+  options: DownloadFileOptions = {},
+): Promise<string> {
+  const response = await fetch(url, buildFetchOptions(url, options));
 
   if (!response.ok) {
     throw new Error(`Failed to download ${url}: ${response.statusText}`);

--- a/src/utils/get-project-config.ts
+++ b/src/utils/get-project-config.ts
@@ -1,5 +1,6 @@
 import path, { isAbsolute } from 'path';
 import fs, { promises as fsPromises } from 'fs';
+import { type ChecksumMode } from './verify-checksum';
 
 const configKey = `natsMemoryServer` as const;
 const configFileBaseName = `nats-memory-server` as const;
@@ -73,6 +74,8 @@ export interface NatsMemoryServerConfig {
   httpProxy?: string;
   httpsProxy?: string;
   noProxy?: string;
+  /** Integrity check for the downloaded archive. Default: `warn`. */
+  verifyChecksum?: ChecksumMode;
 }
 
 const defaultConfig: NatsMemoryServerConfig = {
@@ -81,6 +84,7 @@ const defaultConfig: NatsMemoryServerConfig = {
   version: `v2.9.16`,
   buildFromSource: false,
   binPath: `node_modules/.cache/nats-memory-server/nats-server`,
+  verifyChecksum: `warn`,
 };
 
 function prepareConfig(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from './get-platform';
 export * from './get-arch';
 export * from './get-project-config';
 export * from './with-retry';
+export * from './verify-checksum';

--- a/src/utils/verify-checksum.spec.ts
+++ b/src/utils/verify-checksum.spec.ts
@@ -1,0 +1,193 @@
+import os from 'os';
+import fs from 'fs';
+import path from 'path';
+import {
+  deriveChecksumUrl,
+  parseSha256Sums,
+  sha256OfFile,
+  verifyChecksum,
+} from './verify-checksum';
+
+// Known SHA-256 test vector: sha256("abc").
+const ABC_SHA = `ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad`;
+const RELEASE_URL = `https://github.com/nats-io/nats-server/releases/download/v9.9.9/asset.zip`;
+
+describe(`deriveChecksumUrl`, () => {
+  it(`maps a GitHub release asset URL to its SHA256SUMS URL and asset name`, () => {
+    const result = deriveChecksumUrl(RELEASE_URL);
+    expect(result).toEqual({
+      sumsUrl: `https://github.com/nats-io/nats-server/releases/download/v9.9.9/SHA256SUMS`,
+      assetName: `asset.zip`,
+    });
+  });
+
+  it(`returns null for a source-archive (buildFromSource) URL`, () => {
+    expect(
+      deriveChecksumUrl(
+        `https://github.com/nats-io/nats-server/archive/refs/tags/v9.9.9.zip`,
+      ),
+    ).toBeNull();
+  });
+
+  it(`returns null for a non-release / unparseable URL`, () => {
+    expect(deriveChecksumUrl(`https://my-mirror.example/nats.zip`)).toBeNull();
+    expect(deriveChecksumUrl(`not a url`)).toBeNull();
+  });
+});
+
+describe(`parseSha256Sums`, () => {
+  const sums = [
+    `293013cd810f35f2a3dd25b0d850da248bc45af46b854a805383f848db3e9fa0  nats-server-v9.9.9-windows-amd64.zip`,
+    `51100105ca16c609ab05a12901f1e61b1d997c4ab80c12d722c6d1c0828ab50e  nats-server-v9.9.9-linux-amd64.zip`,
+  ].join(`\n`);
+
+  it(`returns the digest for a matching asset name`, () => {
+    expect(parseSha256Sums(sums, `nats-server-v9.9.9-linux-amd64.zip`)).toBe(
+      `51100105ca16c609ab05a12901f1e61b1d997c4ab80c12d722c6d1c0828ab50e`,
+    );
+  });
+
+  it(`supports the binary-mode "*name" form`, () => {
+    expect(parseSha256Sums(`${ABC_SHA} *asset.zip`, `asset.zip`)).toBe(ABC_SHA);
+  });
+
+  it(`returns null when the asset is absent`, () => {
+    expect(
+      parseSha256Sums(sums, `nats-server-v9.9.9-darwin-arm64.zip`),
+    ).toBeNull();
+  });
+
+  it(`returns null for garbage input`, () => {
+    expect(parseSha256Sums(`not a checksums file`, `asset.zip`)).toBeNull();
+  });
+});
+
+describe(`sha256OfFile`, () => {
+  it(`computes the streaming SHA-256 of a file`, async () => {
+    const file = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), `nms-sha-`)),
+      `data.bin`,
+    );
+    fs.writeFileSync(file, `abc`);
+
+    try {
+      expect(await sha256OfFile(file)).toBe(ABC_SHA);
+    } finally {
+      fs.rmSync(path.dirname(file), { recursive: true, force: true });
+    }
+  });
+});
+
+describe(`verifyChecksum`, () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), `nms-vc-`));
+    file = path.join(dir, `asset.zip`);
+    fs.writeFileSync(file, `abc`); // sha256 == ABC_SHA
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  const deps = (
+    fetchText: jest.Mock,
+    warn: jest.Mock = jest.fn(),
+  ): { fetchText: jest.Mock; logger: { warn: jest.Mock } } => ({
+    fetchText,
+    logger: { warn },
+  });
+
+  it(`mode "off" skips verification entirely and never fetches`, async () => {
+    const fetchText = jest.fn();
+    await expect(
+      verifyChecksum(file, RELEASE_URL, `off`, {}, deps(fetchText)),
+    ).resolves.toBeUndefined();
+    expect(fetchText).not.toHaveBeenCalled();
+  });
+
+  it(`resolves when the downloaded file matches the published digest`, async () => {
+    const fetchText = jest.fn().mockResolvedValue(`${ABC_SHA}  asset.zip`);
+    await expect(
+      verifyChecksum(file, RELEASE_URL, `warn`, {}, deps(fetchText)),
+    ).resolves.toBeUndefined();
+    expect(fetchText).toHaveBeenCalledWith(
+      `https://github.com/nats-io/nats-server/releases/download/v9.9.9/SHA256SUMS`,
+      {},
+    );
+  });
+
+  it(`rejects on a digest MISMATCH in warn mode (tampering is always fatal)`, async () => {
+    const wrong = `0`.repeat(64);
+    const fetchText = jest.fn().mockResolvedValue(`${wrong}  asset.zip`);
+    await expect(
+      verifyChecksum(file, RELEASE_URL, `warn`, {}, deps(fetchText)),
+    ).rejects.toThrow(/checksum/i);
+  });
+
+  it(`rejects on a digest MISMATCH in strict mode`, async () => {
+    const wrong = `0`.repeat(64);
+    const fetchText = jest.fn().mockResolvedValue(`${wrong}  asset.zip`);
+    await expect(
+      verifyChecksum(file, RELEASE_URL, `strict`, {}, deps(fetchText)),
+    ).rejects.toThrow(/checksum/i);
+  });
+
+  it(`warn mode: warns and continues when no digest is available (custom URL)`, async () => {
+    const fetchText = jest.fn();
+    const warn = jest.fn();
+    await expect(
+      verifyChecksum(
+        file,
+        `https://my-mirror.example/nats.zip`,
+        `warn`,
+        {},
+        deps(fetchText, warn),
+      ),
+    ).resolves.toBeUndefined();
+    expect(fetchText).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it(`strict mode: rejects when no digest is available (custom URL)`, async () => {
+    const fetchText = jest.fn();
+    await expect(
+      verifyChecksum(
+        file,
+        `https://my-mirror.example/nats.zip`,
+        `strict`,
+        {},
+        deps(fetchText),
+      ),
+    ).rejects.toThrow();
+  });
+
+  it(`warn mode: warns and continues when SHA256SUMS cannot be fetched`, async () => {
+    const fetchText = jest.fn().mockRejectedValue(new Error(`network down`));
+    const warn = jest.fn();
+    await expect(
+      verifyChecksum(file, RELEASE_URL, `warn`, {}, deps(fetchText, warn)),
+    ).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it(`strict mode: rejects when SHA256SUMS cannot be fetched`, async () => {
+    const fetchText = jest.fn().mockRejectedValue(new Error(`network down`));
+    await expect(
+      verifyChecksum(file, RELEASE_URL, `strict`, {}, deps(fetchText)),
+    ).rejects.toThrow();
+  });
+
+  it(`warn mode: warns and continues when the asset is missing from SHA256SUMS`, async () => {
+    const fetchText = jest
+      .fn()
+      .mockResolvedValue(`${ABC_SHA}  some-other-asset.zip`);
+    const warn = jest.fn();
+    await expect(
+      verifyChecksum(file, RELEASE_URL, `warn`, {}, deps(fetchText, warn)),
+    ).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/src/utils/verify-checksum.ts
+++ b/src/utils/verify-checksum.ts
@@ -1,0 +1,145 @@
+import crypto from 'crypto';
+import { createReadStream } from 'fs';
+import { pipeline } from 'stream/promises';
+import { type DownloadFileOptions } from './download-file';
+
+export type ChecksumMode = `strict` | `warn` | `off`;
+
+export interface VerifyChecksumDeps {
+  fetchText: (url: string, options: DownloadFileOptions) => Promise<string>;
+  logger?: { warn: (message: string, ...args: unknown[]) => void };
+}
+
+const SUMS_FILE_NAME = `SHA256SUMS`;
+const RELEASE_MARKER = `/releases/download/`;
+
+/**
+ * For a GitHub release asset URL
+ * (`.../releases/download/<tag>/<asset>`), returns the sibling `SHA256SUMS`
+ * URL and the asset's filename. Returns `null` for anything else — a source
+ * archive (`/archive/refs/tags/...`), a custom mirror, or an unparseable URL —
+ * which the caller treats as "no digest available".
+ */
+export function deriveChecksumUrl(
+  downloadUrl: string,
+): { sumsUrl: string; assetName: string } | null {
+  let url: URL;
+  try {
+    url = new URL(downloadUrl);
+  } catch {
+    return null;
+  }
+
+  if (!url.pathname.includes(RELEASE_MARKER)) {
+    return null;
+  }
+
+  const segments = url.pathname.split(`/`);
+  const assetName = segments[segments.length - 1];
+
+  if (assetName === ``) {
+    return null;
+  }
+
+  url.pathname = [...segments.slice(0, -1), SUMS_FILE_NAME].join(`/`);
+
+  return { sumsUrl: url.toString(), assetName };
+}
+
+/**
+ * Parses a `sha256sum`-style file and returns the lowercase hex digest for
+ * `assetName`, or `null` if it is not listed. Accepts both the text-mode
+ * (`<hex>  name`) and binary-mode (`<hex> *name`) separators.
+ */
+export function parseSha256Sums(
+  text: string,
+  assetName: string,
+): string | null {
+  for (const line of text.split(`\n`)) {
+    const match = line.trim().match(/^([a-fA-F0-9]{64})\s+\*?(.+)$/);
+
+    if (match != null && match[2].trim() === assetName) {
+      return match[1].toLowerCase();
+    }
+  }
+
+  return null;
+}
+
+/** Streams a file through SHA-256 and returns the lowercase hex digest. */
+export async function sha256OfFile(filePath: string): Promise<string> {
+  const hash = crypto.createHash(`sha256`);
+  await pipeline(createReadStream(filePath), hash);
+  return hash.digest(`hex`);
+}
+
+/**
+ * Verifies `filePath` against the digest published in the release's
+ * `SHA256SUMS`, per `mode`:
+ *  - `off`    — no verification.
+ *  - `warn`   — a detected mismatch aborts; an *unavailable* digest only warns.
+ *  - `strict` — a mismatch OR an unavailable digest aborts.
+ *
+ * A positive mismatch is always fatal (except in `off`): it signals corruption
+ * or tampering, so the downloaded archive must not be used.
+ */
+export async function verifyChecksum(
+  filePath: string,
+  downloadUrl: string,
+  mode: ChecksumMode,
+  options: DownloadFileOptions,
+  deps: VerifyChecksumDeps,
+): Promise<void> {
+  if (mode === `off`) {
+    return;
+  }
+
+  const unavailable = (reason: string): void => {
+    const message = `Could not verify the integrity of ${downloadUrl}: ${reason}`;
+
+    if (mode === `strict`) {
+      throw new Error(
+        `${message}. Aborting because verifyChecksum is "strict" (set it to "warn" or "off" to relax).`,
+      );
+    }
+
+    deps.logger?.warn(
+      `${message}. Continuing because verifyChecksum is "warn".`,
+    );
+  };
+
+  const derived = deriveChecksumUrl(downloadUrl);
+
+  if (derived === null) {
+    unavailable(`no SHA256SUMS could be located for this URL`);
+    return;
+  }
+
+  let sumsText: string;
+  try {
+    sumsText = await deps.fetchText(derived.sumsUrl, options);
+  } catch (error) {
+    unavailable(
+      `failed to download ${derived.sumsUrl} (${
+        error instanceof Error ? error.message : String(error)
+      })`,
+    );
+    return;
+  }
+
+  const expected = parseSha256Sums(sumsText, derived.assetName);
+
+  if (expected === null) {
+    unavailable(`${derived.assetName} is not listed in SHA256SUMS`);
+    return;
+  }
+
+  const actual = await sha256OfFile(filePath);
+
+  if (actual !== expected) {
+    throw new Error(
+      `Checksum mismatch for ${derived.assetName}: expected ${expected}, got ${actual}. ` +
+        `The download may be corrupted or tampered with; refusing to use it.`,
+    );
+  }
+}


### PR DESCRIPTION
Adds opt-out integrity verification of the downloaded NATS release archive **before it is extracted and executed** (postinstall + later `spawn`). Closes the supply-chain gap where a tampered or corrupted archive was run unchecked (audit finding #4).

## How it works
Every NATS release publishes a `SHA256SUMS` file at a predictable URL. On download we derive that URL from the asset URL, fetch it (same proxy handling), look up the asset's digest, hash the downloaded `.zip` (streaming), and compare. No maintained digest table — it works for **any** version automatically.

## New config option
`verifyChecksum: 'strict' | 'warn' | 'off'` (default **`warn`**):

| mode | digest unavailable | digest mismatch |
|------|--------------------|-----------------|
| `strict` | **abort** | **abort** |
| `warn` (default) | warn + continue | **abort** |
| `off` | skip | skip |

A detected **mismatch is always fatal** (only `off` skips the check) — tampering/corruption must never be silently used. `warn` only relaxes the *unavailable* case (custom `downloadUrl`, `buildFromSource`, or `SHA256SUMS` unreachable) so existing custom-mirror / offline setups keep working. A mismatch propagates into the existing `withRetry`, so a corrupt download triggers a fresh attempt.

## Structure
- `src/utils/verify-checksum.ts` — `deriveChecksumUrl`, `parseSha256Sums`, streaming `sha256OfFile`, and `verifyChecksum` (fetch + logger dependency-injected for hermetic tests).
- `fetchText()` added to `download-file.ts` (shared proxy handling).
- Wired into `download.ts` between download and decompress; skipped for `buildFromSource`.

## Verification
- **20 new unit tests**: mode matrix × match/mismatch/unavailable, SHA256SUMS parsing, streaming hash, `fetchText`. Full suite **44 green**, lint clean, `tsc` build OK.
- **End-to-end checked against the live v2.9.16 release** (real `deriveChecksumUrl` + HTTP `fetchText` + `parseSha256Sums` → the expected digest `293013cd…`), so the real wiring — not just the mocked logic — is confirmed to run. (Kept out of the unit suite to keep it network-free.)

## Merge order
Branched off `main`, so it does not include the changes from #100 (`download-file.ts`, `get-project-config.ts`, README) or #101. Expect trivial conflicts — please merge **#100 → #101 → #4** and rebase this one last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)