### PR TITLE
ci(publish): create a GitHub Release on tag push

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-test-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # required for the GITHUB_TOKEN to create a Release
 
     steps:
       - name: Checkout
@@ -39,3 +41,9 @@ jobs:
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        if: ${{ success() }}
+        run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What
After the `npm publish` step, the publish workflow now also creates a **GitHub Release** for the pushed tag using auto-generated notes:

```yaml
- name: Create GitHub Release
  if: ${{ success() }}
  run: gh release create "${GITHUB_REF_NAME}" --generate-notes --verify-tag
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

Plus `permissions: contents: write` on the job so the default `GITHUB_TOKEN` is allowed to create the release.

## Why
Pushing a `vX.Y.Z` tag triggered `npm publish` but **not** a GitHub Release — so tagged versions published to npm without showing up on the `/releases` page (this is why v2.1.0/v2.1.1 had to be created manually). With this change every release tag yields both an npm publish and a Release entry with notes generated from the merged PRs.

## Notes
- Runs only after a successful build/test/publish (`if: ${{ success() }}`).
- `--verify-tag` guards against creating a release for a non-existent tag.
- No effect on the existing npm publish step or secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)