### PR TITLE
fix: drain stdout & harden install scripts (audit backlog)

### DIFF
--- a/src/nats-server.spec.ts
+++ b/src/nats-server.spec.ts
@@ -1,3 +1,4 @@
+import child_process from 'child_process';
 import type { ChildProcessWithoutNullStreams } from 'child_process';
 import { EventEmitter } from 'events';
 import { PassThrough, Readable } from 'stream';
@@ -228,24 +229,32 @@ describe(NatsServer.name, () => {
   });
 
   it(`Should drain stdout so a flood on stdout can't deadlock readiness on stderr`, async () => {
-    const spawn = jest.fn(() =>
-      makeFloodingChild(),
-    ) as unknown as ConstructorParameters<typeof NatsServer>[1];
+    const spawnSpy = jest
+      .spyOn(child_process, `spawn`)
+      .mockImplementation(() => makeFloodingChild());
 
-    const server = new NatsServer(
-      {
+    try {
+      const server = new NatsServer({
         ...DEFAULT_NATS_SERVER_OPTIONS,
         verbose: false,
         port: 4222,
         binPath: `fake-nats-server`,
-      },
-      spawn,
-    );
+      });
 
-    await expect(
-      withTimeout(server.start(), 3000, `start() with flooded stdout`),
-    ).resolves.toBe(server);
+      await expect(
+        withTimeout(server.start(), 3000, `start() with flooded stdout`),
+      ).resolves.toBe(server);
 
-    await server.stop();
+      expect(spawnSpy).toHaveBeenCalledTimes(1);
+      expect(spawnSpy).toHaveBeenCalledWith(
+        `fake-nats-server`,
+        [`--addr`, `127.0.0.1`, `--port`, `4222`],
+        { stdio: `pipe` },
+      );
+
+      await server.stop();
+    } finally {
+      spawnSpy.mockRestore();
+    }
   });
 });

--- a/src/nats-server.spec.ts
+++ b/src/nats-server.spec.ts
@@ -1,7 +1,52 @@
-import { NatsServer } from './nats-server';
+import type { ChildProcessWithoutNullStreams } from 'child_process';
+import { EventEmitter } from 'events';
+import { PassThrough, Readable } from 'stream';
+import { DEFAULT_NATS_SERVER_OPTIONS, NatsServer } from './nats-server';
 import { NatsServerBuilder } from './nats-server.builder';
 import { getFreePort } from './utils';
 import { connect, StringCodec } from 'nats';
+
+/**
+ * A fake child process whose stdout is pre-loaded with more than one OS pipe
+ * buffer of data. The readiness line is written to stderr ONLY after stdout has
+ * been fully consumed — modelling a real child that blocks on a full stdout
+ * pipe until the parent drains it. If start() never reads stdout, readiness is
+ * never reached and start() hangs.
+ */
+function makeFloodingChild(): ChildProcessWithoutNullStreams {
+  const child = new EventEmitter() as unknown as ChildProcessWithoutNullStreams;
+  const stdout = new Readable({
+    read() {
+      // Data is pushed eagerly below; nothing to produce on demand.
+    },
+  });
+  const stderr = new PassThrough();
+
+  Object.assign(child, {
+    stdout,
+    stderr,
+    exitCode: null,
+    signalCode: null,
+    unref: () => {
+      // no-op: the fake child does not keep the event loop alive.
+    },
+    kill: () => {
+      Object.assign(child, { exitCode: 0 });
+      stdout.destroy();
+      stderr.end();
+      queueMicrotask(() => child.emit(`close`, 0, null));
+      return true;
+    },
+  });
+
+  stdout.push(Buffer.alloc(256 * 1024, 0x2e));
+  stdout.push(null);
+  stdout.once(`end`, () => {
+    stderr.write(`[INF] Server is ready\n`);
+  });
+
+  return child;
+}
 
 async function withTimeout<T>(
   promise: Promise<T>,
@@ -180,5 +225,27 @@ describe(NatsServer.name, () => {
     const server = NatsServerBuilder.create({ binPath: undefined }).build();
 
     await expect(server.start()).rejects.toThrow(/binPath/);
+  });
+
+  it(`Should drain stdout so a flood on stdout can't deadlock readiness on stderr`, async () => {
+    const spawn = jest.fn(() =>
+      makeFloodingChild(),
+    ) as unknown as ConstructorParameters<typeof NatsServer>[1];
+
+    const server = new NatsServer(
+      {
+        ...DEFAULT_NATS_SERVER_OPTIONS,
+        verbose: false,
+        port: 4222,
+        binPath: `fake-nats-server`,
+      },
+      spawn,
+    );
+
+    await expect(
+      withTimeout(server.start(), 3000, `start() with flooded stdout`),
+    ).resolves.toBe(server);
+
+    await server.stop();
   });
 });

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -32,12 +32,7 @@ export class NatsServer {
   private host!: string;
   private port!: number;
 
-  constructor(
-    private readonly options: NatsServerOptions,
-    // Injectable so the process boundary can be faked in tests; defaults to
-    // the real spawn so production callers (and the builder) are unaffected.
-    private readonly spawn: typeof child_process.spawn = child_process.spawn,
-  ) {}
+  constructor(private readonly options: NatsServerOptions) {}
 
   async start(): Promise<this> {
     const { verbose, logger } = this.options;
@@ -65,7 +60,7 @@ export class NatsServer {
     }
 
     return await new Promise((resolve, reject) => {
-      this.process = this.spawn(
+      this.process = child_process.spawn(
         binPath,
         [`--addr`, ip, `--port`, port.toString(), ...args],
         { stdio: `pipe` },
@@ -74,9 +69,10 @@ export class NatsServer {
       this.host = ip;
       this.port = port;
 
-      // Drain stdout so a child that writes heavily to stdout (e.g. trace
-      // output, or `--log` pointed at stdout) can't deadlock by filling the OS
-      // pipe buffer while we wait for the readiness line on stderr. We don't
+      // Drain stdout so a child that writes heavily to stdout (e.g. `--log
+      // /dev/stdout`) can't deadlock by filling the OS pipe buffer while we
+      // wait for the readiness line on stderr. nats-server itself logs to
+      // stderr, but we don't control what a custom binPath prints. We don't
       // need stdout's contents, so just let it flow and discard.
       this.process.stdout.resume();
 

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -32,7 +32,12 @@ export class NatsServer {
   private host!: string;
   private port!: number;
 
-  constructor(private readonly options: NatsServerOptions) {}
+  constructor(
+    private readonly options: NatsServerOptions,
+    // Injectable so the process boundary can be faked in tests; defaults to
+    // the real spawn so production callers (and the builder) are unaffected.
+    private readonly spawn: typeof child_process.spawn = child_process.spawn,
+  ) {}
 
   async start(): Promise<this> {
     const { verbose, logger } = this.options;
@@ -60,7 +65,7 @@ export class NatsServer {
     }
 
     return await new Promise((resolve, reject) => {
-      this.process = child_process.spawn(
+      this.process = this.spawn(
         binPath,
         [`--addr`, ip, `--port`, port.toString(), ...args],
         { stdio: `pipe` },
@@ -68,6 +73,12 @@ export class NatsServer {
 
       this.host = ip;
       this.port = port;
+
+      // Drain stdout so a child that writes heavily to stdout (e.g. trace
+      // output, or `--log` pointed at stdout) can't deadlock by filling the OS
+      // pipe buffer while we wait for the readiness line on stderr. We don't
+      // need stdout's contents, so just let it flow and discard.
+      this.process.stdout.resume();
 
       let isReady = false;
 

--- a/src/scripts/build.ts
+++ b/src/scripts/build.ts
@@ -1,14 +1,13 @@
 import fs from 'fs';
 import child_process from 'child_process';
 import { getProjectConfig, getProjectPath } from '../utils';
+import { runInstallStep } from './run-install-step';
 
 async function buildNatsServer(): Promise<void> {
   const projectPath = getProjectPath();
   const config = await getProjectConfig(projectPath);
 
-  const { buildFromSource } = config;
-
-  const { downloadDir, binPath } = config;
+  const { buildFromSource, downloadDir, binPath } = config;
 
   const natsServerNotBuilded = !fs.existsSync(binPath);
 
@@ -39,17 +38,20 @@ async function buildNatsServer(): Promise<void> {
         console.log(data.toString());
       });
 
-      goBuild.on(`close`, (code) => {
+      goBuild.on(`close`, (code, signal) => {
         // Only report success once we know the build actually succeeded, and
         // reject with a real Error (a bare reject() surfaces as `undefined`,
-        // which is useless when the install fails).
+        // which is useless when the install fails). `code` is null exactly
+        // when the child was terminated by a signal, so name the signal then.
         if (code === 0) {
           console.log(`NATS server was builded successful!`);
           resolve();
         } else {
           reject(
             new Error(
-              `go build exited with a non-zero code (${code ?? `null`})`,
+              code === null
+                ? `go build was terminated by signal ${signal ?? `unknown`}`
+                : `go build exited with a non-zero code (${code})`,
             ),
           );
         }
@@ -58,14 +60,4 @@ async function buildNatsServer(): Promise<void> {
   }
 }
 
-process.nextTick(() => {
-  buildNatsServer().catch((error: unknown) => {
-    // Surface a clean message and a deterministic non-zero exit so a failed
-    // build fails `npm install` loudly instead of as an unhandled rejection.
-    console.error(
-      `Failed to build the NATS server from source:`,
-      error instanceof Error ? error.message : error,
-    );
-    process.exit(1);
-  });
-});
+runInstallStep(buildNatsServer, `Failed to build the NATS server from source`);

--- a/src/scripts/build.ts
+++ b/src/scripts/build.ts
@@ -2,13 +2,13 @@ import fs from 'fs';
 import child_process from 'child_process';
 import { getProjectConfig, getProjectPath } from '../utils';
 
-process.nextTick(async function () {
+async function buildNatsServer(): Promise<void> {
   const projectPath = getProjectPath();
   const config = await getProjectConfig(projectPath);
 
   const { buildFromSource } = config;
 
-  let { downloadDir, binPath } = config;
+  const { downloadDir, binPath } = config;
 
   const natsServerNotBuilded = !fs.existsSync(binPath);
 
@@ -18,16 +18,13 @@ process.nextTick(async function () {
 
   if (natsServerNotBuilded) {
     console.log(`Build sources NATS server`);
-    return new Promise<void>((resolve, reject) => {
+    await new Promise<void>((resolve, reject) => {
       const goBuild = child_process.spawn(`go`, [`build`], {
         cwd: downloadDir,
         stdio: `pipe`,
       });
 
-      goBuild.unref();
-
       goBuild.once(`error`, (err) => {
-        console.log(err);
         goBuild.kill();
         reject(err);
       });
@@ -43,14 +40,32 @@ process.nextTick(async function () {
       });
 
       goBuild.on(`close`, (code) => {
-        console.log(`NATS server was builded successful!`);
-
+        // Only report success once we know the build actually succeeded, and
+        // reject with a real Error (a bare reject() surfaces as `undefined`,
+        // which is useless when the install fails).
         if (code === 0) {
+          console.log(`NATS server was builded successful!`);
           resolve();
         } else {
-          reject();
+          reject(
+            new Error(
+              `go build exited with a non-zero code (${code ?? `null`})`,
+            ),
+          );
         }
       });
     });
   }
+}
+
+process.nextTick(() => {
+  buildNatsServer().catch((error: unknown) => {
+    // Surface a clean message and a deterministic non-zero exit so a failed
+    // build fails `npm install` loudly instead of as an unhandled rejection.
+    console.error(
+      `Failed to build the NATS server from source:`,
+      error instanceof Error ? error.message : error,
+    );
+    process.exit(1);
+  });
 });

--- a/src/scripts/download.ts
+++ b/src/scripts/download.ts
@@ -12,6 +12,7 @@ import {
   verifyChecksum,
   withRetry,
 } from '../utils';
+import { runInstallStep } from './run-install-step';
 
 async function downloadNatsServer(): Promise<void> {
   const projectPath = getProjectPath();
@@ -82,14 +83,7 @@ async function downloadNatsServer(): Promise<void> {
   }
 }
 
-process.nextTick(() => {
-  downloadNatsServer().catch((error: unknown) => {
-    // Surface a clean message and a deterministic non-zero exit so a failed
-    // download fails `npm install` loudly instead of as an unhandled rejection.
-    console.error(
-      `Failed to download the NATS server binary:`,
-      error instanceof Error ? error.message : error,
-    );
-    process.exit(1);
-  });
-});
+runInstallStep(
+  downloadNatsServer,
+  `Failed to download the NATS server binary`,
+);

--- a/src/scripts/download.ts
+++ b/src/scripts/download.ts
@@ -13,11 +13,11 @@ import {
   withRetry,
 } from '../utils';
 
-process.nextTick(async function () {
+async function downloadNatsServer(): Promise<void> {
   const projectPath = getProjectPath();
   const config = await getProjectConfig(projectPath);
 
-  let { downloadDir, download } = config;
+  const { downloadDir, download } = config;
 
   const natsServerNotDownload = !fs.existsSync(downloadDir);
 
@@ -80,4 +80,16 @@ process.nextTick(async function () {
       },
     );
   }
+}
+
+process.nextTick(() => {
+  downloadNatsServer().catch((error: unknown) => {
+    // Surface a clean message and a deterministic non-zero exit so a failed
+    // download fails `npm install` loudly instead of as an unhandled rejection.
+    console.error(
+      `Failed to download the NATS server binary:`,
+      error instanceof Error ? error.message : error,
+    );
+    process.exit(1);
+  });
 });

--- a/src/scripts/run-install-step.ts
+++ b/src/scripts/run-install-step.ts
@@ -1,0 +1,31 @@
+import util from 'util';
+
+/**
+ * Runs one postinstall step (download/build) as the script's entrypoint and
+ * turns a rejection into a loud, deterministic install failure.
+ *
+ * The failure path deliberately avoids `process.exit(1)` right after a
+ * console call: process.exit() does not wait for pending asynchronous stdio
+ * writes, and npm runs dependencies' lifecycle scripts with piped stdio by
+ * default, so the diagnostic could be truncated exactly where it matters. Writing through the stream's
+ * flush callback guarantees the message lands first; exiting inside the
+ * callback (rather than relying on `process.exitCode` alone) still guarantees
+ * termination even if a dependency left the event loop alive (e.g. keep-alive
+ * sockets after a failed download).
+ */
+export function runInstallStep(
+  step: () => Promise<void>,
+  failureMessage: string,
+): void {
+  void step().catch((error: unknown) => {
+    // util.inspect keeps non-Error rejections readable (String() would print
+    // a plain object as "[object Object]").
+    const message =
+      error instanceof Error ? error.message : util.inspect(error);
+
+    process.exitCode = 1;
+    process.stderr.write(`${failureMessage}: ${message}\n`, () => {
+      process.exit(1);
+    });
+  });
+}


### PR DESCRIPTION
Closes the still-relevant items from the 2026-06 audit backlog. Three small, low-risk robustness fixes.

## Changes

### 1. `nats-server`: drain stdout (the real fix, TDD'd)
`start()` spawns the child with `stdio: 'pipe'` but only consumed **stderr**. If the child writes more than one OS pipe buffer (~64 KB) to **stdout** — e.g. `--log /dev/stdout`, or a custom `binPath` that prints heavily — the buffer fills, the child blocks on `write()`, and never emits the readiness line on stderr, so `start()` hangs forever.

Fix: `this.process.stdout.resume()` lets stdout flow and be discarded.

The regression test injects a fake child via `jest.spyOn(child_process, 'spawn')` that floods stdout **before** signalling readiness:
- **without** the drain → `start()` times out (the deadlock),
- **with** it → resolves.

No public API changes: the constructor and the emitted `.d.ts` surface are identical to 2.1.1, so the next release can stay a patch.

### 2. `scripts/build`: honest build reporting
- Log `"NATS server was builded successful!"` only when `go build` exits `0` (was logged unconditionally, even on failure).
- `reject(new Error(...))` instead of a bare `reject()` that surfaced as `undefined`; when the child is killed by a signal (`code === null`), the message names the signal instead of saying "non-zero code (null)".
- Drop `unref()` on a process we explicitly `await`.

### 3. `scripts/{download,build}`: fail the install loudly
The postinstall bodies ran as discarded promises. Both now run through a shared `runInstallStep()` helper that prints a clear message and exits `1`, so a failed download/build fails `npm install` deterministically with a readable error instead of an unhandled-rejection stack trace. The diagnostic is written through the stream's flush callback before exiting — a plain `process.exit(1)` right after `console.error` can truncate pending async stdio writes on piped stdio — with `process.exitCode = 1` set as a fallback.

## Review follow-up (07ea3a7)
A multi-agent review of the first commit surfaced 2 minor + 5 nit findings; all addressed, each fix adversarially re-verified:
- the injectable `spawn` constructor parameter (a test seam on the published API) is gone — the test uses `jest.spyOn` instead;
- flush-safe exit path in the install scripts (see above), shared helper instead of duplicated tails, no-op `process.nextTick` wrappers removed;
- signal-aware `go build` failure message; merged config destructuring; accurate drain-comment example.

## Verification
- New regression test for the stdout deadlock (RED→GREEN, re-confirmed after the follow-up: the test times out at 3 s without the drain, passes in ~260 ms with it).
- Full suite: **54 passed** (53 baseline + 1 new).
- `npm run build`, `npm run lint` clean; emitted `dist/*.d.ts` surface verified identical to `main`.

## Not included (intentionally)
Backlog items ruled out as non-issues or out of scope: arch/platform maps resolve correctly for all common platforms via passthrough; `getFreePort` TOCTOU is inherent to the bind-then-release pattern; `unref()` in `nats-server` is intentional so a forgotten server doesn't hang the test runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
