### PR TITLE
chore(docker): remove broken, unused root Dockerfile and .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,0 @@
-node_modules
-dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM node:18-alpine3.18
-WORKDIR /usr/src
-COPY . .
-RUN apk add go &&\
-    npm install &&\
-    npm run build
-


### PR DESCRIPTION
## Summary

Deletes the root `Dockerfile` and `.dockerignore`. They are broken, stale, and serve no purpose.

## Why delete instead of fix

**It's broken — verified by actually building it.** `.dockerignore` excludes `dist`, but `postinstall` (added in ad460b1, Jul 2024) runs `node ./dist/scripts/download.js && node ./dist/scripts/build.js` during the image's `npm install` step, before `npm run build` ever runs:

```
npm error command sh -c node ./dist/scripts/download.js && node ./dist/scripts/build.js
ERROR: process "/bin/sh -c apk add go &&    npm install &&    npm run build" did not complete successfully: exit code: 1
```

So it has failed for ~2 years with zero reports — nobody builds it.

**It never had a real purpose.** It was added in ffc1765 (Jun 2023) as a Linux build sandbox for the `buildFromSource` feature (hence `apk add go`) and never touched again. It has no `CMD`/`ENTRYPOINT`/`EXPOSE` — the image builds the library and stops. Its companion root config `nats-memory-server.ts` (pointing `binPath` at `/usr/sbin/nats-server`) is being removed by the open #105 — that config is invalid and silently ignored anyway.

**Nothing references it.** Checked before deleting:

- No CI workflow uses it; `test.yml` already covers Linux (ubuntu-latest) with the correct `npm ci --ignore-scripts` → `npm run build` → `npm run postinstall` sequence.
- `git grep -i docker` across **all revisions** of README/docs/.github: the only hit is the README's pitch that this package *eliminates* the need for Docker in tests.
- No issue or PR mentions the Dockerfile (only docker-adjacent hit is #96, an unrelated decompress error in GH Actions).
- No container image was ever published: Docker Hub (no `nats-memory-server` repo under any of the author's namespaces), GHCR/GitHub Packages tab empty, npm README has no Docker instructions.

If a containerized dev environment is ever wanted, a devcontainer mirroring `test.yml`'s install sequence would be the right tool — easy to add fresh when there's an actual need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
