### PR TITLE
fix(husky): add prepare script so git hooks install on fresh clones

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "tsc -p ./tsconfig.build.json",
     "prepublishOnly": "npm run build",
     "postinstall": "node ./dist/scripts/download.js && node ./dist/scripts/build.js",
+    "prepare": "husky install",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write \"**/*.ts\"",
     "test": "jest"


### PR DESCRIPTION
## Problem

husky v8 is a devDependency and `.husky/pre-commit` exists, but `package.json` has no `prepare` script, so `husky install` never runs on a fresh clone. Result: `.husky/_/husky.sh` is missing, and on machines where `core.hooksPath` points at `.husky`, every `git commit` fails with:

```
.husky/_/husky.sh: No such file or directory
```

## Fix

Add the standard husky v8 idiom:

```json
"prepare": "husky install"
```

## Why this is safe

- **CI (test/publish workflows)**: `npm ci --ignore-scripts` skips `prepare` — fine, CI does not need git hooks.
- **`npm publish`**: runs `prepare` in the Actions checkout, where `.git` exists and devDependencies are installed, so `husky install` succeeds (it just sets `core.hooksPath` in that clone).
- **Package consumers**: npm never runs a registry dependency's `prepare`; git-URL installs run it inside a real clone with devDependencies, so it also succeeds.

## Note for contributors

A truly fresh clone can't run plain `npm install` anyway (the `postinstall` script references gitignored `dist/`), so first-time setup remains `npm ci --ignore-scripts` + `npm run build`. After that, run `npm run prepare` once (or any later plain `npm install` will trigger it) to activate hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
