### PR TITLE
feat(config): wire runtime options from project config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,30 +112,34 @@ Provide it via any of: `nats-memory-server.json` · `nats-memory-server.js` · `
 
 ### Installation options
 
-| Option            | Type                          | Default                                       | Description                                                        |
-| ----------------- | ----------------------------- | --------------------------------------------- | ------------------------------------------------------------------ |
-| `download`        | `boolean`                     | `true`                                        | Download the binary during `postinstall`.                          |
-| `downloadDir`     | `string`                      | `node_modules/.cache/nats-memory-server`      | Where the downloaded binary is cached.                             |
-| `version`         | `string`                      | `v2.9.16`                                     | `nats-server` version to download.                                 |
-| `buildFromSource` | `boolean`                     | `false`                                       | Build from source instead of downloading (requires Go).            |
-| `binPath`         | `string`                      | *(cache path above)*                          | Path to the `nats-server` binary.                                  |
-| `httpProxy`       | `string`                      | –                                             | Proxy URL for HTTP requests.                                       |
-| `httpsProxy`      | `string`                      | –                                             | Proxy URL for HTTPS requests.                                      |
-| `noProxy`         | `string`                      | –                                             | Domains that bypass the proxy.                                     |
-| `verifyChecksum`  | `'strict' \| 'warn' \| 'off'` | `warn`                                        | Integrity-check the download against the release `SHA256SUMS`.     |
+| Option            | Type                          | Default                                  | Description                                                    |
+| ----------------- | ----------------------------- | ---------------------------------------- | -------------------------------------------------------------- |
+| `download`        | `boolean`                     | `true`                                   | Download the binary during `postinstall`.                      |
+| `downloadDir`     | `string`                      | `node_modules/.cache/nats-memory-server` | Where the downloaded binary is cached.                         |
+| `version`         | `string`                      | `v2.9.16`                                | `nats-server` version to download.                             |
+| `buildFromSource` | `boolean`                     | `false`                                  | Build from source instead of downloading (requires Go).        |
+| `binPath`         | `string`                      | _(cache path above)_                     | Path to the `nats-server` binary.                              |
+| `httpProxy`       | `string`                      | –                                        | Proxy URL for HTTP requests.                                   |
+| `httpsProxy`      | `string`                      | –                                        | Proxy URL for HTTPS requests.                                  |
+| `noProxy`         | `string`                      | –                                        | Domains that bypass the proxy.                                 |
+| `verifyChecksum`  | `'strict' \| 'warn' \| 'off'` | `warn`                                   | Integrity-check the download against the release `SHA256SUMS`. |
 
 > 🔒 **`verifyChecksum`** — a checksum **mismatch always aborts** the install (only `off` skips the check entirely).
-> `warn` (default) additionally just *warns* when a checksum can't be obtained (custom `downloadUrl`, `buildFromSource`,
+> `warn` (default) additionally just _warns_ when a checksum can't be obtained (custom `downloadUrl`, `buildFromSource`,
 > or an unreachable `SHA256SUMS`); `strict` aborts in that case too.
 
 ### Runtime options
 
-| Option    | Type       | Default               | Description                                                                              |
-| --------- | ---------- | --------------------- | ---------------------------------------------------------------------------------------- |
-| `port`    | `number`   | *(random free port)*  | Port to listen on.                                                                       |
-| `ip`      | `string`   | `127.0.0.1`           | Bind address. Use `0.0.0.0` to expose on all interfaces — ⚠️ the broker has no auth.     |
-| `verbose` | `boolean`  | `true`                | Verbose logging.                                                                         |
-| `args`    | `string[]` | `[]`                  | Extra arguments passed straight to `nats-server`.                                        |
+| Option    | Type       | Default              | Description                                                                          |
+| --------- | ---------- | -------------------- | ------------------------------------------------------------------------------------ |
+| `port`    | `number`   | _(random free port)_ | Port to listen on.                                                                   |
+| `ip`      | `string`   | `127.0.0.1`          | Bind address. Use `0.0.0.0` to expose on all interfaces — ⚠️ the broker has no auth. |
+| `verbose` | `boolean`  | `true`               | Verbose logging.                                                                     |
+| `args`    | `string[]` | `[]`                 | Extra arguments passed straight to `nats-server`.                                    |
+
+Runtime options can also be set in code, via [`NatsServerBuilder`](#natsserverbuilder) setters or the `NatsServer`
+constructor. Precedence (highest first): **options set explicitly in code → config file → built-in defaults**.
+A custom `logger` can only be provided in code.
 
 <details>
 <summary><b>Example config files</b></summary>
@@ -172,9 +176,12 @@ Full default configuration
   "binPath": "node_modules/.cache/nats-memory-server/nats-server",
   "verifyChecksum": "warn",
   "verbose": true,
-  "ip": "127.0.0.1"
+  "ip": "127.0.0.1",
+  "args": []
 }
 ```
+
+(`port` has no fixed default — a random free port is picked at start.)
 
 </details>
 
@@ -186,26 +193,26 @@ Full default configuration
 
 Fluent builder for `NatsServer` instances — every setter returns `this`, so calls chain.
 
-| Method                                | Description                                                         |
-| ------------------------------------- | ------------------------------------------------------------------ |
-| `static create(options?)`             | Create a new builder, optionally seeded with partial options.      |
-| `setPort(port: number)`               | Set the listen port.                                               |
-| `setIp(ip: string)`                   | Set the bind address.                                              |
-| `setVerbose(verbose: boolean)`        | Toggle verbose logging.                                            |
-| `setArgs(args: string[])`             | Set extra `nats-server` arguments.                                 |
-| `setBinPath(binPath: string)`         | Set the path to the `nats-server` binary.                          |
-| `setLogger(logger: Logger)`           | Provide a custom logger (`log`, `error`, `warn`, `debug`).         |
-| `build()`                             | Build and return a `NatsServer`.                                   |
+| Method                         | Description                                                   |
+| ------------------------------ | ------------------------------------------------------------- |
+| `static create(options?)`      | Create a new builder, optionally seeded with partial options. |
+| `setPort(port: number)`        | Set the listen port.                                          |
+| `setIp(ip: string)`            | Set the bind address.                                         |
+| `setVerbose(verbose: boolean)` | Toggle verbose logging.                                       |
+| `setArgs(args: string[])`      | Set extra `nats-server` arguments.                            |
+| `setBinPath(binPath: string)`  | Set the path to the `nats-server` binary.                     |
+| `setLogger(logger: Logger)`    | Provide a custom logger (`log`, `error`, `warn`, `debug`).    |
+| `build()`                      | Build and return a `NatsServer`.                              |
 
 ### `NatsServer`
 
-| Method      | Returns         | Description                                                            |
-| ----------- | --------------- | --------------------------------------------------------------------- |
-| `start()`   | `Promise<this>` | Start the server; resolves once it is ready (rejects if it can't).    |
-| `stop()`    | `Promise<void>` | Stop the server.                                                      |
-| `getUrl()`  | `string`        | Connection URL, e.g. `nats://127.0.0.1:4222`.                         |
-| `getHost()` | `string`        | The bind host.                                                        |
-| `getPort()` | `number`        | The listen port.                                                      |
+| Method      | Returns         | Description                                                        |
+| ----------- | --------------- | ------------------------------------------------------------------ |
+| `start()`   | `Promise<this>` | Start the server; resolves once it is ready (rejects if it can't). |
+| `stop()`    | `Promise<void>` | Stop the server.                                                   |
+| `getUrl()`  | `string`        | Connection URL, e.g. `nats://127.0.0.1:4222`.                      |
+| `getHost()` | `string`        | The bind host.                                                     |
+| `getPort()` | `number`        | The listen port.                                                   |
 
 ---
 
@@ -228,10 +235,11 @@ await NatsServerBuilder.create()
 
 ```ts
 const os = require('os');
-const { NatsServer, DEFAULT_NATS_SERVER_OPTIONS } = require('nats-memory-server');
+const { NatsServer } = require('nats-memory-server');
 
+// Options are partial: anything you don't set comes from your config file
+// or the built-in defaults.
 new NatsServer({
-  ...DEFAULT_NATS_SERVER_OPTIONS,
   args: ['--jetstream', '--store_dir', os.tmpdir()],
 });
 ```
@@ -271,7 +279,7 @@ test('should publish and subscribe', async () => {
 ## 📋 Requirements
 
 - **Node.js** ≥ 16
-- **[Go](https://golang.org/)** ≥ 1.19 — *optional*, only needed when `buildFromSource` is enabled
+- **[Go](https://golang.org/)** ≥ 1.19 — _optional_, only needed when `buildFromSource` is enabled
 
 ---
 

--- a/src/nats-server.builder.spec.ts
+++ b/src/nats-server.builder.spec.ts
@@ -1,11 +1,12 @@
 import { NatsServerBuilder } from './nats-server.builder';
-import { DEFAULT_NATS_SERVER_OPTIONS } from './nats-server';
 
 describe(NatsServerBuilder.name, () => {
-  it(`Should create builder with default options`, () => {
+  it(`Should keep options empty when nothing is set (defaults are resolved at start())`, () => {
+    // Baking DEFAULT_NATS_SERVER_OPTIONS in at build time would make every
+    // option look explicitly set, so a project config file could never win.
     const builder = NatsServerBuilder.create();
     const server = builder.build();
-    expect((server as any).options).toEqual(DEFAULT_NATS_SERVER_OPTIONS);
+    expect((server as any).options).toEqual({});
   });
 
   it(`Should set custom options via create`, () => {

--- a/src/nats-server.builder.ts
+++ b/src/nats-server.builder.ts
@@ -1,16 +1,14 @@
-import {
-  type NatsServerOptions,
-  NatsServer,
-  DEFAULT_NATS_SERVER_OPTIONS,
-  type Logger,
-} from './index';
+import { type NatsServerOptions, NatsServer, type Logger } from './index';
 
 export class NatsServerBuilder {
-  private options: NatsServerOptions = DEFAULT_NATS_SERVER_OPTIONS;
+  // Keep only the options that were explicitly provided. Built-in defaults
+  // and the project config file are merged in NatsServer.start(), so an
+  // option left unset here can still be supplied by a config file.
+  private options: Partial<NatsServerOptions> = {};
 
   constructor(options?: Partial<NatsServerOptions>) {
     if (options != null) {
-      this.options = { ...this.options, ...options };
+      this.options = { ...options };
     }
   }
 

--- a/src/nats-server.project-config.spec.ts
+++ b/src/nats-server.project-config.spec.ts
@@ -1,0 +1,222 @@
+import child_process from 'child_process';
+import type { ChildProcessWithoutNullStreams } from 'child_process';
+import { EventEmitter } from 'events';
+import { PassThrough } from 'stream';
+import { NatsServer, type Logger } from './nats-server';
+import { NatsServerBuilder } from './nats-server.builder';
+import { getFreePort, getProjectConfig } from './utils';
+import { type NatsMemoryServerConfig } from './utils';
+
+jest.mock(`./utils`, () => {
+  const actual = jest.requireActual(`./utils`);
+  return {
+    ...actual,
+    getProjectConfig: jest.fn(),
+    getFreePort: jest.fn(),
+  };
+});
+
+const getProjectConfigMock = getProjectConfig as jest.MockedFunction<
+  typeof getProjectConfig
+>;
+const getFreePortMock = getFreePort as jest.MockedFunction<typeof getFreePort>;
+
+/**
+ * A fake child process that becomes "ready" on its own: the readiness line is
+ * written to stderr on the next macrotask, after start() has attached its
+ * stream listeners. Lets these tests assert the exact spawn arguments without
+ * needing a real nats-server binary.
+ */
+function makeFakeChild(): ChildProcessWithoutNullStreams {
+  const child = new EventEmitter() as unknown as ChildProcessWithoutNullStreams;
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+
+  Object.assign(child, {
+    stdout,
+    stderr,
+    exitCode: null,
+    signalCode: null,
+    unref: () => {
+      // no-op: the fake child does not keep the event loop alive.
+    },
+    kill: () => {
+      Object.assign(child, { exitCode: 0 });
+      stdout.end();
+      stderr.end();
+      queueMicrotask(() => child.emit(`close`, 0, null));
+      return true;
+    },
+  });
+
+  setImmediate(() => {
+    stderr.write(`[INF] Server is ready\n`);
+  });
+
+  return child;
+}
+
+function makeProjectConfig(
+  overrides: Partial<NatsMemoryServerConfig> = {},
+): NatsMemoryServerConfig {
+  return {
+    download: true,
+    downloadDir: `/tmp/nats-memory-server-cache`,
+    version: `v2.9.16`,
+    buildFromSource: false,
+    binPath: `config-bin`,
+    ...overrides,
+  };
+}
+
+function makeLogger(): Logger & {
+  log: jest.Mock;
+  error: jest.Mock;
+  warn: jest.Mock;
+  debug: jest.Mock;
+} {
+  return {
+    log: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  };
+}
+
+describe(`${NatsServer.name} project-config runtime options`, () => {
+  let spawnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    spawnSpy = jest
+      .spyOn(child_process, `spawn`)
+      .mockImplementation(() => makeFakeChild());
+    getFreePortMock.mockResolvedValue(23456);
+  });
+
+  afterEach(() => {
+    spawnSpy.mockRestore();
+    getProjectConfigMock.mockReset();
+    getFreePortMock.mockReset();
+  });
+
+  it(`Should apply runtime options from the project config when not set explicitly`, async () => {
+    getProjectConfigMock.mockResolvedValue(
+      makeProjectConfig({
+        verbose: false,
+        ip: `127.0.0.2`,
+        port: 41234,
+        args: [`--jetstream`],
+      }),
+    );
+
+    const logger = makeLogger();
+    const server = NatsServerBuilder.create().setLogger(logger).build();
+
+    await server.start();
+
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    expect(spawnSpy).toHaveBeenCalledWith(
+      `config-bin`,
+      [`--addr`, `127.0.0.2`, `--port`, `41234`, `--jetstream`],
+      { stdio: `pipe` },
+    );
+
+    await server.stop();
+
+    // verbose: false from the project config must silence start/stop logging.
+    expect(logger.log).not.toHaveBeenCalled();
+  });
+
+  it(`Should let explicit builder options override the project config`, async () => {
+    getProjectConfigMock.mockResolvedValue(
+      makeProjectConfig({
+        verbose: false,
+        ip: `127.0.0.3`,
+        port: 1111,
+        args: [`--from-config`],
+      }),
+    );
+
+    const logger = makeLogger();
+    const server = NatsServerBuilder.create()
+      .setVerbose(true)
+      .setIp(`127.0.0.4`)
+      .setPort(2222)
+      .setArgs([`--explicit`])
+      .setBinPath(`explicit-bin`)
+      .setLogger(logger)
+      .build();
+
+    await server.start();
+
+    expect(spawnSpy).toHaveBeenCalledWith(
+      `explicit-bin`,
+      [`--addr`, `127.0.0.4`, `--port`, `2222`, `--explicit`],
+      { stdio: `pipe` },
+    );
+
+    // verbose: true set explicitly wins over the config's false.
+    expect(logger.log).toHaveBeenCalled();
+
+    await server.stop();
+  });
+
+  it(`Should fall back to built-in defaults when neither config nor options set a value`, async () => {
+    getProjectConfigMock.mockResolvedValue(makeProjectConfig());
+
+    const logger = makeLogger();
+    const server = NatsServerBuilder.create().setLogger(logger).build();
+
+    await server.start();
+
+    // ip defaults to loopback, port to a free port, binPath flows from config.
+    expect(spawnSpy).toHaveBeenCalledWith(
+      `config-bin`,
+      [`--addr`, `127.0.0.1`, `--port`, `23456`],
+      { stdio: `pipe` },
+    );
+
+    // verbose defaults to true.
+    expect(logger.log).toHaveBeenCalled();
+
+    await server.stop();
+
+    // stop() must observe the same resolved options as start(): with verbose
+    // defaulting to true it logs the shutdown. Reading the raw (partial)
+    // constructor options here would leave verbose undefined and stay silent.
+    expect(logger.log).toHaveBeenCalledWith(
+      `NATS server was stop at:`,
+      expect.any(String),
+    );
+  });
+
+  it(`Should let an explicitly-set undefined override the project config`, async () => {
+    getProjectConfigMock.mockResolvedValue(
+      makeProjectConfig({ binPath: `config-bin` }),
+    );
+
+    const server = NatsServerBuilder.create({ binPath: undefined })
+      .setLogger(makeLogger())
+      .build();
+
+    await expect(server.start()).rejects.toThrow(/binPath/);
+  });
+
+  it(`Should support new NatsServer() with no arguments`, async () => {
+    getProjectConfigMock.mockResolvedValue(
+      makeProjectConfig({ verbose: false }),
+    );
+
+    const server = new NatsServer();
+
+    await server.start();
+
+    expect(spawnSpy).toHaveBeenCalledWith(
+      `config-bin`,
+      [`--addr`, `127.0.0.1`, `--port`, `23456`],
+      { stdio: `pipe` },
+    );
+
+    await server.stop();
+  });
+});

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -1,5 +1,10 @@
 import child_process from 'child_process';
-import { getFreePort, getProjectConfig, getProjectPath } from './utils';
+import {
+  getFreePort,
+  getProjectConfig,
+  getProjectPath,
+  type NatsMemoryServerConfig,
+} from './utils';
 export interface Logger {
   log: (message: string, ...args: unknown[]) => void;
   error: (message: string, ...args: unknown[]) => void;
@@ -26,16 +31,66 @@ export const DEFAULT_NATS_SERVER_OPTIONS = {
   logger: console,
 } satisfies NatsServerOptions;
 
+/**
+ * Extract the runtime options a project config file may provide. Only keys
+ * actually present in the config are returned, so an absent key never
+ * shadows a built-in default when spread.
+ */
+function pickRuntimeOptions(
+  config: NatsMemoryServerConfig,
+): Partial<NatsServerOptions> {
+  const runtime: Partial<NatsServerOptions> = {};
+
+  if (config.verbose !== undefined) {
+    runtime.verbose = config.verbose;
+  }
+  if (config.ip !== undefined) {
+    runtime.ip = config.ip;
+  }
+  if (config.port !== undefined) {
+    runtime.port = config.port;
+  }
+  if (config.args !== undefined) {
+    runtime.args = config.args;
+  }
+  if (config.binPath !== undefined) {
+    runtime.binPath = config.binPath;
+  }
+
+  return runtime;
+}
+
 export class NatsServer {
   private process?: child_process.ChildProcessWithoutNullStreams;
 
   private host!: string;
   private port!: number;
 
-  constructor(private readonly options: NatsServerOptions) {}
+  /** The options start() actually ran with, after merging in the defaults
+   * and the project config; used by stop() so both ends of the lifecycle
+   * observe the same `verbose`/`logger`. */
+  private resolvedOptions?: NatsServerOptions;
+
+  constructor(private readonly options: Partial<NatsServerOptions> = {}) {}
 
   async start(): Promise<this> {
-    const { verbose, logger } = this.options;
+    // getProjectConfig memoizes per project path (and no longer caches a
+    // rejection), so calling it directly each start() is both cheap and
+    // recoverable — no separate static promise cache is needed here.
+    const projectConfig = await getProjectConfig(getProjectPath());
+
+    // Precedence: built-in defaults < project config file < options passed
+    // explicitly to the builder/constructor. Plain spreads keep an
+    // explicitly-set `undefined` overriding the config (e.g. a deliberate
+    // `{ binPath: undefined }` must not silently fall back).
+    const config: NatsServerOptions = {
+      ...DEFAULT_NATS_SERVER_OPTIONS,
+      ...pickRuntimeOptions(projectConfig),
+      ...this.options,
+    };
+    this.resolvedOptions = config;
+
+    const { verbose, logger } = config;
 
     if (this.process != null) {
       const message = `Nats server already started at ${this.getUrl()}`;
@@ -47,12 +102,6 @@ export class NatsServer {
       return this;
     }
 
-    // getProjectConfig memoizes per project path (and no longer caches a
-    // rejection), so calling it directly each start() is both cheap and
-    // recoverable — no separate static promise cache is needed here.
-    const projectConfig = await getProjectConfig(getProjectPath());
-
-    const config = { ...projectConfig, ...this.options };
     const { args, ip, port = await getFreePort(), binPath } = config;
 
     if (binPath == null) {
@@ -178,7 +227,13 @@ export class NatsServer {
       return;
     }
 
-    const { verbose, logger } = this.options;
+    // start() assigns resolvedOptions before it ever spawns the child, so it
+    // is always defined when a child handle exists; the fallback merge is
+    // purely type-level defensiveness.
+    const { verbose, logger } = this.resolvedOptions ?? {
+      ...DEFAULT_NATS_SERVER_OPTIONS,
+      ...this.options,
+    };
 
     // The child has already exited (it crashed, or stop() was called before).
     // kill() would be a no-op that never emits `close`, so awaiting one here

--- a/src/utils/get-project-config.spec.ts
+++ b/src/utils/get-project-config.spec.ts
@@ -24,4 +24,30 @@ describe(`getProjectConfig`, () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it(`passes runtime options from a config file through, typed`, async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), `nms-cfg-`));
+    const configPath = path.join(dir, `nats-memory-server.json`);
+
+    try {
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          verbose: false,
+          port: 43333,
+          ip: `0.0.0.0`,
+          args: [`--jetstream`],
+        }),
+      );
+
+      const config = await getProjectConfig(dir);
+
+      expect(config.verbose).toBe(false);
+      expect(config.port).toBe(43333);
+      expect(config.ip).toBe(`0.0.0.0`);
+      expect(config.args).toEqual([`--jetstream`]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/utils/get-project-config.ts
+++ b/src/utils/get-project-config.ts
@@ -76,6 +76,14 @@ export interface NatsMemoryServerConfig {
   noProxy?: string;
   /** Integrity check for the downloaded archive. Default: `warn`. */
   verifyChecksum?: ChecksumMode;
+  /** Runtime: port the server listens on. Default: a random free port. */
+  port?: number;
+  /** Runtime: bind address. Default: `127.0.0.1`. */
+  ip?: string;
+  /** Runtime: verbose logging. Default: `true`. */
+  verbose?: boolean;
+  /** Runtime: extra CLI arguments passed to `nats-server`. Default: `[]`. */
+  args?: string[];
 }
 
 const defaultConfig: NatsMemoryServerConfig = {


### PR DESCRIPTION
## Problem

The README's Configuration section documents that runtime options (`port`, `ip`, `verbose`, `args`) can be provided via config files (`nats-memory-server.json/.js/.ts` or the `natsMemoryServer` key in `package.json`) — its JSON example even sets `"verbose": false`. In reality they could never take effect:

- `NatsServerBuilder` baked `DEFAULT_NATS_SERVER_OPTIONS` into every instance at construction, so every option always looked "explicitly set".
- `NatsServer.start()` destructured `verbose`/`logger` from constructor options **before** loading the project config, and merged `{ ...projectConfig, ...this.options }` with constructor options last — so the built-in defaults always won. Only `binPath` (and `port`, when unset) ever flowed through.
- `NatsMemoryServerConfig` didn't declare the runtime fields at all.

This became user-visible after #105 made `.ts`/`.js` config files actually load.

## Fix

Precedence is now: **built-in defaults < project config file < explicitly-set builder/constructor options.**

- `NatsServerBuilder` keeps only the options that were explicitly provided; defaults are resolved in `start()`.
- `NatsServer` accepts `Partial<NatsServerOptions>` (and `new NatsServer()` with no arguments now works) — a non-breaking loosening of the signature.
- `start()` resolves the full config up front via a `pickRuntimeOptions()` helper that only copies keys actually present in the project config, so an absent key never shadows a default; `stop()` observes the same resolved options through a `resolvedOptions` field.
- Plain spreads deliberately keep an explicitly-passed `undefined` overriding the config (the existing `{ binPath: undefined }` rejection test still passes).
- `NatsMemoryServerConfig` now declares `port` / `ip` / `verbose` / `args`.
- README: precedence note in the Runtime options section, `"args": []` added to the full-default block, and the JetStream constructor example no longer needs to spread `DEFAULT_NATS_SERVER_OPTIONS`.

## Compatibility

Semver-minor: config-file keys like `verbose`/`ip`/`args` that were previously silently ignored now take effect, matching what the README has promised all along. Code that passes options explicitly is unaffected — explicit options still win.

Note for #105: once `export default` configs are unwrapped, their runtime options will flow through this same path; merge order between the two PRs doesn't matter (#105 also deletes the repo-root config file).

## Testing

- New `src/nats-server.project-config.spec.ts` (mocked `getProjectConfig` + fake child process): config-provided runtime options apply; explicit builder options override the config; built-in defaults fill remaining gaps; explicit `undefined` still overrides; zero-argument constructor; stop-time logging observes the resolved options (mutation-checked: reverting `stop()` to the raw partial options fails the test).
- `getProjectConfig` now has a test that runtime fields in a config file flow through, typed.
- Builder spec updated: building without setters yields empty options (defaults resolved at start).
- Full suite: 60/60 passing locally (including real-binary integration tests); lint and `tsc` clean. TDD: all new tests were watched failing for the expected reasons first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
