### PR TITLE
chore(release): 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nats-memory-server",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nats-memory-server",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nats-memory-server",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "Node.js package for an in-memory NATS server",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Version bump `2.1.1` → `2.2.0` to cut a release. Pushing the `v2.2.0` tag after this merges will trigger the publish workflow (npm + GitHub Release).

Minor bump because #108 adds new functionality.

Included since 2.1.1:
- **feat(config)**: wire runtime options from project config files (#108) — semver-minor
- **fix(config)**: unwrap ES-module default export from `.ts`/`.js` configs (#105)
- **fix(husky)**: add `prepare` script so git hooks install on fresh clones (#107)
- **chore(docker)**: remove broken, unused root Dockerfile (#106)

Only `package.json` / `package-lock.json` version fields change.

https://claude.ai/code/session_01PuTD3DMQwoqUgtzVVn2j1n

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuTD3DMQwoqUgtzVVn2j1n)_