### PR TITLE
feat: opt-in monitoring port with /healthz readiness and bounded start timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,41 @@ new NatsServer({
 
 ---
 
+## 📈 Monitoring & readiness
+
+Enable the `nats-server` HTTP monitoring endpoint and read its URL. When monitoring
+is enabled, readiness is detected via `GET /healthz` instead of scanning the log
+output, which is robust to log formatting and routing.
+
+```ts
+const { NatsServerBuilder } = require('nats-memory-server');
+
+const server = await NatsServerBuilder.create()
+  .enableMonitoring() // or .setMonitoringPort(8222) for a fixed port
+  .build()
+  .start();
+
+console.log(server.getMonitoringUrl()); // e.g. http://127.0.0.1:8222
+// GET `${server.getMonitoringUrl()}/healthz` -> 200 {"status":"ok"}
+// GET `${server.getMonitoringUrl()}/varz`    -> server stats
+```
+
+| Method | Description |
+| ------------------------------ | ------------------------------------------------------------ |
+| `enableMonitoring()`           | Enable monitoring on an automatically chosen free port.       |
+| `disableMonitoring()`          | Disable monitoring (the default).                             |
+| `setMonitoringPort(port)`      | Enable monitoring on an explicit port.                        |
+| `getMonitoringUrl()`           | `http://host:port` when enabled and started, else `undefined`.|
+
+Monitoring is **off by default**. It can also be set in a config file via
+`"monitoring": true` (or a port number).
+
+`start()` is bounded by a readiness timeout (default `30000` ms). Adjust it with
+`setStartTimeout(ms)` or the `startTimeoutMs` config option; on expiry `start()`
+rejects and the child process is terminated.
+
+---
+
 ## 🧪 Testing with Jest
 
 Spin up one server per suite — start it in `beforeAll`, tear it down in `afterAll`:

--- a/README.md
+++ b/README.md
@@ -276,12 +276,16 @@ console.log(server.getMonitoringUrl()); // e.g. http://127.0.0.1:8222
 // GET `${server.getMonitoringUrl()}/varz`    -> server stats
 ```
 
+**Builder methods**
+
 | Method | Description |
 | ------------------------------ | ------------------------------------------------------------ |
 | `enableMonitoring()`           | Enable monitoring on an automatically chosen free port.       |
 | `disableMonitoring()`          | Disable monitoring (the default).                             |
 | `setMonitoringPort(port)`      | Enable monitoring on an explicit port.                        |
-| `getMonitoringUrl()`           | `http://host:port` when enabled and started, else `undefined`.|
+| `setStartTimeout(ms)`          | Override the readiness timeout (default `30000` ms).          |
+
+**`server.getMonitoringUrl(): string | undefined`** — `http://host:port` when monitoring is enabled and the server has started, otherwise `undefined`.
 
 Monitoring is **off by default**. It can also be set in a config file via
 `"monitoring": true` (or a port number).

--- a/docs/superpowers/plans/2026-06-23-monitoring-port.md
+++ b/docs/superpowers/plans/2026-06-23-monitoring-port.md
@@ -1,0 +1,972 @@
+# Opt-in Monitoring Port + Robust Readiness — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in HTTP monitoring port (`enableMonitoring()`/`setMonitoringPort()` → `getMonitoringUrl()`), use `GET /healthz` for deterministic readiness when it is enabled, and add a bounded start timeout so `start()` can never hang forever.
+
+**Architecture:** A new `waitForHealthz` poller (node:http) is the readiness signal when monitoring is enabled; the existing stderr `Server is ready` scan remains the signal when monitoring is off. A single `AbortController` + `setTimeout` inside `start()` bounds both paths and is cleared/aborted in every settlement path. Monitoring is **off by default**, so default spawn args and behavior are unchanged except that `start()` is now time-bounded.
+
+**Tech Stack:** TypeScript (CommonJS, strict, target es2016), Node’s built-in `http`/`AbortController`, Jest + ts-jest. The real `nats-server` v2.9.16 binary is used for integration tests.
+
+## Global Constraints
+
+- **Monitoring off by default.** `monitoring` default is `false`; when off, the `spawn` argument array MUST stay exactly `['--addr', ip, '--port', String(port), ...args]` (an existing test asserts this).
+- **Use `node:http`** for the healthz poll — NOT `make-fetch-happen`. The endpoint is always local; no proxy handling, no new dependency.
+- **Config precedence:** built-in defaults < project config file < explicit code options. New options participate via `pickRuntimeOptions`.
+- **String style:** every string literal uses **backticks** (the repo’s `@typescript-eslint/quotes` rule). Match it.
+- **Node ≥ 16** baseline (`AbortController`, `AbortSignal`, `http.get(url, { signal }, cb)` are all available).
+- **Pre-commit hook runs `npm test` (full suite) + lint-staged.** The worktree already has the binary cached at `node_modules/.cache/nats-memory-server/nats-server.exe`, so integration tests run here.
+- **Spec:** [docs/superpowers/specs/2026-06-23-monitoring-port-design.md](../specs/2026-06-23-monitoring-port-design.md).
+- Verified vs the real v2.9.16 binary: flag is `-m, --http_port <port>`; `GET /healthz` → `200 {"status":"ok"}`; the monitor binds to the `--addr` host.
+
+---
+
+## Task 1: `waitForHealthz` polling utility
+
+**Files:**
+- Create: `src/utils/wait-for-healthz.ts`
+- Test: `src/utils/wait-for-healthz.spec.ts`
+- Modify: `src/utils/index.ts` (add one export line)
+
+**Interfaces:**
+- Produces: `waitForHealthz(url: string, options?: { intervalMs?: number; signal?: AbortSignal }): Promise<void>` — resolves on the first 2xx, retries other responses/errors after `intervalMs` (default 50), rejects only when `signal` aborts. Also exports `interface WaitForHealthzOptions`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/utils/wait-for-healthz.spec.ts`:
+
+```ts
+import http from 'http';
+import type { AddressInfo } from 'net';
+import { waitForHealthz } from './wait-for-healthz';
+
+async function startServer(
+  handler: http.RequestListener,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = http.createServer(handler);
+  await new Promise<void>((resolve) => {
+    server.listen(0, `127.0.0.1`, resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/healthz`,
+    close: async () =>
+      await new Promise<void>((resolve) => {
+        server.close(() => {
+          resolve();
+        });
+      }),
+  };
+}
+
+describe(`waitForHealthz`, () => {
+  it(`resolves once the endpoint returns 200`, async () => {
+    const { url, close } = await startServer((_req, res) => {
+      res.writeHead(200);
+      res.end(`{"status":"ok"}`);
+    });
+    try {
+      await expect(
+        waitForHealthz(url, { intervalMs: 10 }),
+      ).resolves.toBeUndefined();
+    } finally {
+      await close();
+    }
+  });
+
+  it(`retries through non-2xx responses until one succeeds`, async () => {
+    let hits = 0;
+    const { url, close } = await startServer((_req, res) => {
+      hits += 1;
+      if (hits < 3) {
+        res.writeHead(503);
+        res.end(`not ready`);
+      } else {
+        res.writeHead(200);
+        res.end(`ok`);
+      }
+    });
+    try {
+      await expect(
+        waitForHealthz(url, { intervalMs: 10 }),
+      ).resolves.toBeUndefined();
+      expect(hits).toBeGreaterThanOrEqual(3);
+    } finally {
+      await close();
+    }
+  });
+
+  it(`rejects when the signal aborts`, async () => {
+    const { url, close } = await startServer((_req, res) => {
+      res.writeHead(503);
+      res.end(`never ready`);
+    });
+    const controller = new AbortController();
+    setTimeout(() => {
+      controller.abort();
+    }, 50);
+    try {
+      await expect(
+        waitForHealthz(url, { intervalMs: 10, signal: controller.signal }),
+      ).rejects.toThrow(/aborted/);
+    } finally {
+      await close();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx jest src/utils/wait-for-healthz.spec.ts`
+Expected: FAIL — `Cannot find module './wait-for-healthz'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/utils/wait-for-healthz.ts`:
+
+```ts
+import http from 'http';
+
+export interface WaitForHealthzOptions {
+  /** Delay between poll attempts in milliseconds. Default: 50. */
+  intervalMs?: number;
+  /** Abort to stop polling; the returned promise rejects when aborted. */
+  signal?: AbortSignal;
+}
+
+const DEFAULT_INTERVAL_MS = 50;
+
+/** A single GET. Resolves true on a 2xx response, false on any error/non-2xx. */
+async function probeOnce(url: string, signal?: AbortSignal): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const request = http.get(url, { signal }, (response) => {
+      const status = response.statusCode ?? 0;
+      response.resume(); // drain so the socket frees promptly
+      resolve(status >= 200 && status < 300);
+    });
+    request.on(`error`, () => {
+      resolve(false);
+    });
+  });
+}
+
+async function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return await new Promise<void>((resolve, reject) => {
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(new Error(`waitForHealthz aborted`));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener(`abort`, onAbort);
+      resolve();
+    }, ms);
+    if (signal != null) {
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      signal.addEventListener(`abort`, onAbort, { once: true });
+    }
+  });
+}
+
+/**
+ * Polls `GET <url>` until it returns a 2xx response, then resolves. Connection
+ * errors and non-2xx responses (the server is still coming up) are retried
+ * after `intervalMs`. Rejects only when `signal` aborts. Uses node:http — the
+ * target is always local, so no proxy handling is needed.
+ */
+export async function waitForHealthz(
+  url: string,
+  options: WaitForHealthzOptions = {},
+): Promise<void> {
+  const { intervalMs = DEFAULT_INTERVAL_MS, signal } = options;
+
+  for (;;) {
+    if (signal?.aborted === true) {
+      throw new Error(`waitForHealthz aborted`);
+    }
+
+    if (await probeOnce(url, signal)) {
+      return;
+    }
+
+    await delay(intervalMs, signal);
+  }
+}
+```
+
+Add to `src/utils/index.ts` (append after the last export):
+
+```ts
+export * from './wait-for-healthz';
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx jest src/utils/wait-for-healthz.spec.ts`
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/wait-for-healthz.ts src/utils/wait-for-healthz.spec.ts src/utils/index.ts
+git commit -m "feat: add waitForHealthz polling utility"
+```
+
+---
+
+## Task 2: Options, config fields, and builder setters (plumbing)
+
+Adds the `monitoring` and `startTimeoutMs` options, their config-file fields, their config-merge wiring, and the four builder methods. **No `start()` behavior changes yet** — those land in Task 3.
+
+**Files:**
+- Modify: `src/nats-server.ts` (`NatsServerOptions`, `DEFAULT_NATS_SERVER_OPTIONS`, `pickRuntimeOptions`)
+- Modify: `src/utils/get-project-config.ts` (`NatsMemoryServerConfig`)
+- Modify: `src/nats-server.builder.ts` (four new methods)
+- Test: `src/nats-server.builder.spec.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  - `NatsServerOptions` gains `monitoring: boolean | number` and `startTimeoutMs: number`.
+  - `NatsServerBuilder.enableMonitoring(): this` (sets `monitoring = true`), `disableMonitoring(): this` (sets `monitoring = false`), `setMonitoringPort(port: number): this` (sets `monitoring = port`), `setStartTimeout(ms: number): this` (sets `startTimeoutMs = ms`).
+  - `NatsMemoryServerConfig` gains optional `monitoring?: boolean | number` and `startTimeoutMs?: number`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `describe` block in `src/nats-server.builder.spec.ts`:
+
+```ts
+it(`Should enable monitoring`, () => {
+  const server = NatsServerBuilder.create().enableMonitoring().build();
+  expect((server as any).options.monitoring).toBe(true);
+});
+
+it(`Should disable monitoring`, () => {
+  const server = NatsServerBuilder.create().disableMonitoring().build();
+  expect((server as any).options.monitoring).toBe(false);
+});
+
+it(`Should set an explicit monitoring port`, () => {
+  const server = NatsServerBuilder.create().setMonitoringPort(8222).build();
+  expect((server as any).options.monitoring).toBe(8222);
+});
+
+it(`Should apply last-call-wins across monitoring setters`, () => {
+  const a = NatsServerBuilder.create()
+    .enableMonitoring()
+    .setMonitoringPort(8222)
+    .build();
+  expect((a as any).options.monitoring).toBe(8222);
+
+  const b = NatsServerBuilder.create()
+    .setMonitoringPort(8222)
+    .disableMonitoring()
+    .build();
+  expect((b as any).options.monitoring).toBe(false);
+});
+
+it(`Should set the start timeout`, () => {
+  const server = NatsServerBuilder.create().setStartTimeout(5000).build();
+  expect((server as any).options.startTimeoutMs).toBe(5000);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx jest src/nats-server.builder.spec.ts`
+Expected: FAIL — `enableMonitoring is not a function` (and the others).
+
+- [ ] **Step 3: Implement the option type and defaults**
+
+In `src/nats-server.ts`, extend the `NatsServerOptions` interface (add the two fields):
+
+```ts
+export interface NatsServerOptions {
+  verbose: boolean;
+  args: string[];
+  port?: number;
+  ip: string;
+  logger: Logger;
+  binPath?: string;
+  /** HTTP monitoring port: `false` disables it, `true` picks a free port, a number uses that port. */
+  monitoring: boolean | number;
+  /** How long start() waits for readiness before failing, in milliseconds. */
+  startTimeoutMs: number;
+}
+```
+
+Extend `DEFAULT_NATS_SERVER_OPTIONS` (add the two defaults):
+
+```ts
+export const DEFAULT_NATS_SERVER_OPTIONS = {
+  verbose: true,
+  // Bind to loopback by default so the ephemeral test broker is not exposed,
+  // unauthenticated, on every network interface. Opt into a wider bind (e.g.
+  // `0.0.0.0`) explicitly via setIp() when cross-host access is actually needed.
+  ip: `127.0.0.1`,
+  args: [],
+  logger: console,
+  monitoring: false,
+  startTimeoutMs: 30000,
+} satisfies NatsServerOptions;
+```
+
+Extend `pickRuntimeOptions` (add two blocks before `return runtime;`):
+
+```ts
+  if (config.monitoring !== undefined) {
+    runtime.monitoring = config.monitoring;
+  }
+  if (config.startTimeoutMs !== undefined) {
+    runtime.startTimeoutMs = config.startTimeoutMs;
+  }
+```
+
+In `src/utils/get-project-config.ts`, add to the `NatsMemoryServerConfig` interface (after the existing `args?` field):
+
+```ts
+  /** Runtime: HTTP monitoring port. `false` (default) / `true` (free port) / number. */
+  monitoring?: boolean | number;
+  /** Runtime: readiness timeout in milliseconds. Default: `30000`. */
+  startTimeoutMs?: number;
+```
+
+- [ ] **Step 4: Implement the builder methods**
+
+In `src/nats-server.builder.ts`, add these methods inside the class (e.g. after `setArgs`):
+
+```ts
+  enableMonitoring(): this {
+    this.options = { ...this.options, monitoring: true };
+    return this;
+  }
+
+  disableMonitoring(): this {
+    this.options = { ...this.options, monitoring: false };
+    return this;
+  }
+
+  setMonitoringPort(port: number): this {
+    this.options = { ...this.options, monitoring: port };
+    return this;
+  }
+
+  setStartTimeout(ms: number): this {
+    this.options = { ...this.options, startTimeoutMs: ms };
+    return this;
+  }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx jest src/nats-server.builder.spec.ts`
+Expected: PASS — the new tests plus all existing builder tests.
+
+- [ ] **Step 6: Verify nothing else regressed (no behavior change yet)**
+
+Run: `npx jest src/nats-server.spec.ts src/nats-server.project-config.spec.ts`
+Expected: PASS — defaults add `monitoring:false`/`startTimeoutMs:30000`, so spawn args and readiness are unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/nats-server.ts src/utils/get-project-config.ts src/nats-server.builder.ts src/nats-server.builder.spec.ts
+git commit -m "feat: add monitoring/startTimeout options and builder setters"
+```
+
+---
+
+## Task 3: Rewrite `start()` — bounded timeout + monitoring/healthz readiness
+
+Consumes the Task 2 options. Adds the `monitorPort` field, `getMonitoringUrl()`, the `-m` spawn arg, a shared `AbortController` + timeout, and the healthz readiness path. This is where the three new behaviors become live.
+
+**Files:**
+- Modify: `src/nats-server.ts` (import, `monitorPort` field, `start()`, `getMonitoringUrl()`)
+- Test: `src/nats-server.spec.ts`
+- Test: `src/nats-server.project-config.spec.ts`
+
+**Interfaces:**
+- Consumes: `waitForHealthz` (Task 1); `NatsServerOptions.monitoring` / `.startTimeoutMs` (Task 2).
+- Produces: `NatsServer.getMonitoringUrl(): string | undefined` — `http://<host>:<monitorPort>` when monitoring is enabled and `start()` resolved; otherwise `undefined`.
+
+- [ ] **Step 1: Write the failing tests (nats-server.spec.ts)**
+
+In `src/nats-server.spec.ts`, add the `http` import at the top (with the other imports):
+
+```ts
+import http from 'http';
+```
+
+Add this fake-child helper next to `makeFloodingChild` (a child that spawns, stays alive, and never signals readiness on its own):
+
+```ts
+/**
+ * A fake child that spawns successfully and stays alive but NEVER writes a
+ * readiness line. Used to exercise the start timeout and the healthz path,
+ * where readiness must come from somewhere other than stderr.
+ */
+function makeSilentChild(): ChildProcessWithoutNullStreams {
+  const child = new EventEmitter() as unknown as ChildProcessWithoutNullStreams;
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+
+  Object.assign(child, {
+    stdout,
+    stderr,
+    exitCode: null,
+    signalCode: null,
+    unref: () => {
+      // no-op
+    },
+    kill: () => {
+      Object.assign(child, { exitCode: 0 });
+      stdout.end();
+      stderr.end();
+      queueMicrotask(() => child.emit(`close`, 0, null));
+      return true;
+    },
+  });
+
+  return child;
+}
+```
+
+Add these tests inside the `describe(NatsServer.name, ...)` block:
+
+```ts
+it(`Should reject start() if the server never becomes ready within the timeout`, async () => {
+  const spawnSpy = jest
+    .spyOn(child_process, `spawn`)
+    .mockImplementation(() => makeSilentChild());
+
+  try {
+    const server = NatsServerBuilder.create()
+      .setVerbose(false)
+      .setBinPath(`fake-nats-server`)
+      .setStartTimeout(150)
+      .build();
+
+    await expect(server.start()).rejects.toThrow(/did not become ready/);
+  } finally {
+    spawnSpy.mockRestore();
+  }
+});
+
+it(`Should return undefined from getMonitoringUrl when monitoring is disabled`, () => {
+  const server = NatsServerBuilder.create().build();
+  expect(server.getMonitoringUrl()).toBeUndefined();
+});
+
+it(`Should become ready via /healthz and expose getMonitoringUrl when monitoring is enabled`, async () => {
+  const monitorPort = await getFreePort();
+  const healthServer = http.createServer((req, res) => {
+    if (req.url === `/healthz`) {
+      res.writeHead(200);
+      res.end(`{"status":"ok"}`);
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  });
+  await new Promise<void>((resolve) => {
+    healthServer.listen(monitorPort, `127.0.0.1`, resolve);
+  });
+
+  const spawnSpy = jest
+    .spyOn(child_process, `spawn`)
+    .mockImplementation(() => makeSilentChild());
+
+  try {
+    const server = NatsServerBuilder.create()
+      .setVerbose(false)
+      .setBinPath(`fake-nats-server`)
+      .setIp(`127.0.0.1`)
+      .setPort(45330)
+      .setMonitoringPort(monitorPort)
+      .build();
+
+    await withTimeout(server.start(), 5000, `monitoring start()`);
+
+    expect(server.getMonitoringUrl()).toBe(`http://127.0.0.1:${monitorPort}`);
+    expect(spawnSpy).toHaveBeenCalledWith(
+      `fake-nats-server`,
+      [`--addr`, `127.0.0.1`, `--port`, `45330`, `-m`, String(monitorPort)],
+      { stdio: `pipe` },
+    );
+
+    await server.stop();
+  } finally {
+    spawnSpy.mockRestore();
+    await new Promise<void>((resolve) => {
+      healthServer.close(() => {
+        resolve();
+      });
+    });
+  }
+});
+
+it(`Should expose a working /healthz endpoint with the real server`, async () => {
+  const server = await NatsServerBuilder.create()
+    .setVerbose(false)
+    .enableMonitoring()
+    .build()
+    .start();
+
+  try {
+    const url = server.getMonitoringUrl();
+    expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+
+    const status = await new Promise<number>((resolve, reject) => {
+      http
+        .get(`${url as string}/healthz`, (res) => {
+          res.resume();
+          resolve(res.statusCode ?? 0);
+        })
+        .on(`error`, reject);
+    });
+    expect(status).toBe(200);
+
+    const nc = await connect({ servers: server.getUrl() });
+    expect(nc.isClosed()).toBe(false);
+    await nc.close();
+  } finally {
+    await server.stop();
+  }
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx jest src/nats-server.spec.ts`
+Expected: FAIL — `getMonitoringUrl is not a function`; the timeout test does not reject (start hangs → its own `withTimeout`/jest timeout); the `-m` arg assertion fails.
+
+- [ ] **Step 3: Implement — import, field, getMonitoringUrl, and the new start()**
+
+In `src/nats-server.ts`, update the import to include `waitForHealthz`:
+
+```ts
+import {
+  getFreePort,
+  getProjectConfig,
+  getProjectPath,
+  waitForHealthz,
+  type NatsMemoryServerConfig,
+} from './utils';
+```
+
+Add the field next to `private port!: number;`:
+
+```ts
+  private monitorPort?: number;
+```
+
+Replace the entire `start()` method with:
+
+```ts
+  async start(): Promise<this> {
+    const projectConfig = await getProjectConfig(getProjectPath());
+
+    const config: NatsServerOptions = {
+      ...DEFAULT_NATS_SERVER_OPTIONS,
+      ...pickRuntimeOptions(projectConfig),
+      ...this.options,
+    };
+    this.resolvedOptions = config;
+
+    const { verbose, logger } = config;
+
+    if (this.process != null) {
+      const message = `Nats server already started at ${this.getUrl()}`;
+
+      if (verbose) {
+        logger.warn(message);
+      }
+
+      return this;
+    }
+
+    const {
+      args,
+      ip,
+      port = await getFreePort(),
+      binPath,
+      monitoring,
+      startTimeoutMs,
+    } = config;
+
+    if (binPath == null) {
+      throw new Error(`Could not resolve a binPath for the NATS server binary`);
+    }
+
+    // Resolve the monitoring port. `undefined` means monitoring is disabled; a
+    // free port is allocated when monitoring is enabled without an explicit one.
+    const monitorPort =
+      monitoring === false
+        ? undefined
+        : typeof monitoring === `number`
+        ? monitoring
+        : await getFreePort();
+
+    this.host = ip;
+    this.port = port;
+    this.monitorPort = monitorPort;
+
+    const spawnArgs =
+      monitorPort !== undefined
+        ? [
+            `--addr`,
+            ip,
+            `--port`,
+            port.toString(),
+            `-m`,
+            monitorPort.toString(),
+            ...args,
+          ]
+        : [`--addr`, ip, `--port`, port.toString(), ...args];
+
+    return await new Promise((resolve, reject) => {
+      const child = child_process.spawn(binPath, spawnArgs, { stdio: `pipe` });
+      this.process = child;
+
+      // Drain stdout so a child that writes heavily to stdout can't deadlock by
+      // filling the OS pipe buffer while we wait for readiness.
+      child.stdout.resume();
+
+      let isReady = false;
+      let settled = false;
+
+      // A single controller + timer bounds the whole readiness wait and stops
+      // the healthz poller. Cleared/aborted in every settlement path so nothing
+      // outlives start().
+      const controller = new AbortController();
+
+      const settleReject = (error: Error): void => {
+        clearTimeout(timer);
+        controller.abort();
+        if (settled) {
+          return;
+        }
+        settled = true;
+        this.process = undefined;
+        reject(error);
+      };
+
+      const markReady = (): void => {
+        if (settled) {
+          return;
+        }
+        isReady = true;
+        settled = true;
+        clearTimeout(timer);
+        controller.abort();
+        if (verbose) {
+          logger.log(`NATS server is ready!`);
+        }
+        resolve(this);
+        child.unref();
+      };
+
+      const timer = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+        // Kill the child we could not confirm ready, then fail loudly.
+        child.kill();
+        if (verbose) {
+          logger.warn(
+            `NATS server did not become ready within ${startTimeoutMs}ms`,
+          );
+        }
+        settleReject(
+          new Error(
+            `NATS server did not become ready within ${startTimeoutMs}ms`,
+          ),
+        );
+      }, startTimeoutMs);
+      timer.unref();
+
+      child.once(`error`, (err) => {
+        if (verbose) {
+          logger.error(`NATS server error:`, err);
+        }
+        // After readiness, settleReject() is a no-op (settled) and leaves the
+        // running handle intact — a transient post-ready error must not tear it
+        // down. Before readiness it rejects the start Promise.
+        settleReject(err);
+      });
+
+      // When monitoring is enabled, readiness is decided by the HTTP monitoring
+      // endpoint — deterministic and independent of log text.
+      if (monitorPort !== undefined) {
+        const healthHost = ip === `0.0.0.0` ? `127.0.0.1` : ip;
+        const healthUrl = `http://${healthHost}:${monitorPort}/healthz`;
+        void waitForHealthz(healthUrl, { signal: controller.signal })
+          .then(() => {
+            markReady();
+          })
+          .catch(() => {
+            // Aborted by the timeout/error/close path, which has already
+            // settled the Promise; nothing to do here.
+          });
+      }
+
+      child.stderr.on(`data`, (data: unknown) => {
+        // Once ready, non-verbose mode has nothing left to do on this stream.
+        if (isReady && !verbose) {
+          return;
+        }
+
+        let dataStr: string | undefined;
+        if (Buffer.isBuffer(data)) {
+          if (verbose) {
+            dataStr = data.toString();
+          }
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-base-to-string
+          dataStr = data?.toString();
+        }
+
+        if (verbose && dataStr != null) {
+          logger.log(dataStr);
+        }
+
+        // Stderr is the readiness signal only when monitoring is disabled.
+        if (monitorPort === undefined && !isReady) {
+          const ready = Buffer.isBuffer(data)
+            ? data.includes(`Server is ready`)
+            : dataStr?.includes(`Server is ready`) === true;
+
+          if (ready) {
+            markReady();
+          }
+        }
+      });
+
+      child.once(`close`, (code) => {
+        // The child has exited: clear the handle so a later stop() does not
+        // kill() a dead process and so start() can spawn a fresh server later.
+        this.process = undefined;
+        clearTimeout(timer);
+        controller.abort();
+
+        if (verbose) {
+          logger.log(`NATS server was stop!`);
+        }
+
+        // Exiting before readiness is always a failure regardless of exit code.
+        if (!settled) {
+          const message = `NATS server exited before becoming ready${
+            code !== null ? ` (exit code: ${code})` : ``
+          }`;
+
+          if (verbose) {
+            logger.warn(message, code);
+          }
+
+          settleReject(new Error(message));
+        }
+      });
+    });
+  }
+```
+
+Add the `getMonitoringUrl()` method (next to `getUrl()`):
+
+```ts
+  public getMonitoringUrl(): string | undefined {
+    if (this.monitorPort === undefined) {
+      return undefined;
+    }
+    return `http://${this.host}:${this.monitorPort}`;
+  }
+```
+
+- [ ] **Step 4: Run the nats-server tests to verify they pass**
+
+Run: `npx jest src/nats-server.spec.ts`
+Expected: PASS — new timeout/monitoring/healthz tests plus all existing tests (the flood test’s exact-args assertion still holds because monitoring defaults to off).
+
+- [ ] **Step 5: Write the config-file failing tests (project-config.spec.ts)**
+
+In `src/nats-server.project-config.spec.ts`, add imports at the top:
+
+```ts
+import http from 'http';
+import type { AddressInfo } from 'net';
+```
+
+Add a never-ready fake child helper next to `makeFakeChild`:
+
+```ts
+function makeNeverReadyChild(): ChildProcessWithoutNullStreams {
+  const child = new EventEmitter() as unknown as ChildProcessWithoutNullStreams;
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+
+  Object.assign(child, {
+    stdout,
+    stderr,
+    exitCode: null,
+    signalCode: null,
+    unref: () => {
+      // no-op
+    },
+    kill: () => {
+      Object.assign(child, { exitCode: 0 });
+      stdout.end();
+      stderr.end();
+      queueMicrotask(() => child.emit(`close`, 0, null));
+      return true;
+    },
+  });
+
+  return child;
+}
+```
+
+Add these tests inside the `describe(...)` block:
+
+```ts
+it(`Should enable monitoring from the project config`, async () => {
+  const healthServer = http.createServer((_req, res) => {
+    res.writeHead(200);
+    res.end(`{"status":"ok"}`);
+  });
+  await new Promise<void>((resolve) => {
+    healthServer.listen(0, `127.0.0.1`, resolve);
+  });
+  const monitorPort = (healthServer.address() as AddressInfo).port;
+
+  getProjectConfigMock.mockResolvedValue(
+    makeProjectConfig({ verbose: false, monitoring: monitorPort }),
+  );
+
+  const server = NatsServerBuilder.create().setLogger(makeLogger()).build();
+
+  await server.start();
+
+  expect(spawnSpy).toHaveBeenCalledWith(
+    `config-bin`,
+    [`--addr`, `127.0.0.1`, `--port`, `23456`, `-m`, String(monitorPort)],
+    { stdio: `pipe` },
+  );
+  expect(server.getMonitoringUrl()).toBe(`http://127.0.0.1:${monitorPort}`);
+
+  await server.stop();
+  await new Promise<void>((resolve) => {
+    healthServer.close(() => {
+      resolve();
+    });
+  });
+});
+
+it(`Should fail fast using startTimeoutMs from the project config`, async () => {
+  spawnSpy.mockImplementation(() => makeNeverReadyChild());
+  getProjectConfigMock.mockResolvedValue(
+    makeProjectConfig({ verbose: false, startTimeoutMs: 120 }),
+  );
+
+  const server = NatsServerBuilder.create().setLogger(makeLogger()).build();
+
+  await expect(server.start()).rejects.toThrow(/did not become ready/);
+});
+```
+
+- [ ] **Step 6: Run the project-config tests to verify they pass**
+
+Run: `npx jest src/nats-server.project-config.spec.ts`
+Expected: PASS — the two new tests plus all existing config tests (monitoring stays off in those, so their exact-args assertions are unchanged).
+
+- [ ] **Step 7: Run the full suite**
+
+Run: `npm test`
+Expected: PASS — all suites.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/nats-server.ts src/nats-server.spec.ts src/nats-server.project-config.spec.ts
+git commit -m "feat: monitoring port with /healthz readiness and bounded start timeout"
+```
+
+---
+
+## Task 4: Document the feature and verify the build
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add a Monitoring section to the README**
+
+Insert this section immediately after the JetStream `</details>` block (around `README.md:256`, before the `---` that precedes “🧪 Testing with Jest”):
+
+````markdown
+---
+
+## 📈 Monitoring & readiness
+
+Enable the `nats-server` HTTP monitoring endpoint and read its URL. When monitoring
+is enabled, readiness is detected via `GET /healthz` instead of scanning the log
+output, which is robust to log formatting and routing.
+
+```ts
+const { NatsServerBuilder } = require('nats-memory-server');
+
+const server = await NatsServerBuilder.create()
+  .enableMonitoring() // or .setMonitoringPort(8222) for a fixed port
+  .build()
+  .start();
+
+console.log(server.getMonitoringUrl()); // e.g. http://127.0.0.1:8222
+// GET `${server.getMonitoringUrl()}/healthz` -> 200 {"status":"ok"}
+// GET `${server.getMonitoringUrl()}/varz`    -> server stats
+```
+
+| Method | Description |
+| ------------------------------ | ------------------------------------------------------------ |
+| `enableMonitoring()`           | Enable monitoring on an automatically chosen free port.       |
+| `disableMonitoring()`          | Disable monitoring (the default).                             |
+| `setMonitoringPort(port)`      | Enable monitoring on an explicit port.                        |
+| `getMonitoringUrl()`           | `http://host:port` when enabled and started, else `undefined`.|
+
+Monitoring is **off by default**. It can also be set in a config file via
+`"monitoring": true` (or a port number).
+
+`start()` is bounded by a readiness timeout (default `30000` ms). Adjust it with
+`setStartTimeout(ms)` or the `startTimeoutMs` config option; on expiry `start()`
+rejects and the child process is terminated.
+````
+
+- [ ] **Step 2: Verify the full suite still passes**
+
+Run: `npm test`
+Expected: PASS — all suites (docs-only change).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document monitoring port, getMonitoringUrl, and start timeout"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `enableMonitoring`/`disableMonitoring`/`setMonitoringPort`/`setStartTimeout` → Task 2.
+- `getMonitoringUrl()` → Task 3 (Step 3) + tests.
+- `monitoring` / `startTimeoutMs` options + defaults + config-file fields + precedence → Task 2 (+ config-file tests in Task 3 Steps 5–6).
+- `-m` spawn arg only when enabled; default args unchanged → Task 3 (asserted by the monitoring test’s args check and the unchanged flood/config tests).
+- `/healthz` readiness via `waitForHealthz` (node:http) → Task 1 + Task 3.
+- Bounded timeout + AbortController, cleared/aborted in all settlement paths → Task 3 (Step 3).
+- `0.0.0.0` → poll `127.0.0.1` → Task 3 (`healthHost`).
+- README monitoring docs → Task 4.
+- Out-of-scope items (client-port race, orphan cleanup, stop() timeout) are intentionally not implemented.
+
+**Placeholder scan:** none — every code step contains full code; every run step has an exact command and expected result.
+
+**Type consistency:** `monitoring: boolean | number` and `startTimeoutMs: number` are used identically across `NatsServerOptions`, `DEFAULT_NATS_SERVER_OPTIONS`, `pickRuntimeOptions`, `NatsMemoryServerConfig`, and the builder. `waitForHealthz(url, { intervalMs?, signal? })` matches between Task 1’s definition and Task 3’s call. `getMonitoringUrl(): string | undefined` matches between definition and tests. `monitorPort` (resolved local + `this.monitorPort` field) is consistent.

--- a/docs/superpowers/specs/2026-06-23-monitoring-port-design.md
+++ b/docs/superpowers/specs/2026-06-23-monitoring-port-design.md
@@ -1,0 +1,195 @@
+# Design: opt-in monitoring port + robust readiness
+
+**Date:** 2026-06-23
+**Status:** approved (pending written-spec review)
+**Scope:** Step "B" of the growth roadmap — add an opt-in HTTP monitoring port and,
+when it is enabled, use `GET /healthz` for deterministic readiness. Add a bounded
+start timeout so `start()` can never hang forever. The free-port TOCTOU race for the
+**client** port is explicitly **out of scope** (a later step, "C").
+
+---
+
+## 1. Motivation
+
+Today `start()` ([src/nats-server.ts](../../../src/nats-server.ts)) decides readiness
+solely by substring-matching `Server is ready` on the child's **stderr**
+(`src/nats-server.ts:166-169`) and has **no timeout** — so if that exact line never
+reaches stderr (custom `binPath` printing to stdout, `--log`/`--syslog` redirecting the
+banner, upstream wording drift) `await server.start()` hangs indefinitely.
+
+There is also no way to reach the `nats-server` HTTP monitoring endpoints
+(`/healthz`, `/varz`, …) from a test.
+
+This step adds an opt-in monitoring port that both (a) exposes those endpoints via
+`getMonitoringUrl()`, and (b) becomes a deterministic readiness signal that does not
+depend on log text. A bounded start timeout is added regardless of monitoring, which
+also fixes the indefinite-hang defect for the default path.
+
+## 2. Verified facts (nats-server v2.9.16, checked against the real binary)
+
+- Flag: `-m, --http_port <port>` (HTTP monitoring). `--ports_file_dir <dir>` also exists.
+- `GET http://<host>:<m>/healthz` → `200` with body `{"status":"ok"}` once ready.
+- The HTTP monitor binds to the **`--addr` host**: starting with `-a 127.0.0.1 -m <m>`
+  yields `/varz` `http_host: 127.0.0.1`. So `getMonitoringUrl()` = `http://<ip>:<m>`.
+- `/varz` reports the real client `host`/`port` (relevant to the later port-race step,
+  not used here).
+
+## 3. Public API
+
+### Builder — `NatsServerBuilder`
+
+| Method | Behavior |
+| --- | --- |
+| `enableMonitoring(): this` | Enable monitoring; the monitoring port is auto-allocated (a free port) at `start()`. Sets `monitoring = true`. |
+| `disableMonitoring(): this` | Disable monitoring (the default). Sets `monitoring = false`. |
+| `setMonitoringPort(port: number): this` | Enable monitoring on an explicit port. Sets `monitoring = <port>`. |
+| `setStartTimeout(ms: number): this` | Set the readiness timeout. Sets `startTimeoutMs`. |
+
+All three monitoring setters write the **same** internal field `monitoring` and obey
+**last-call-wins**, e.g. `enableMonitoring().setMonitoringPort(8222)` → port `8222`;
+`setMonitoringPort(8222).disableMonitoring()` → disabled.
+
+### Server — `NatsServer`
+
+| Method | Returns | Behavior |
+| --- | --- | --- |
+| `getMonitoringUrl()` | `string \| undefined` | `http://<host>:<monitorPort>` when monitoring is enabled **and** `start()` has resolved; `undefined` when monitoring is disabled or the server has not started. |
+
+(`getMonitoringPort()` is intentionally omitted for now — YAGNI; can be added later.)
+
+### Config file — `NatsMemoryServerConfig`
+
+New optional runtime fields, honored with the existing precedence
+(**defaults < config file < explicit code options**):
+
+- `monitoring?: boolean | number` — `false` (default) / `true` (auto port) / `<port>`.
+- `startTimeoutMs?: number`.
+
+## 4. Options & defaults
+
+`NatsServerOptions` ([src/nats-server.ts](../../../src/nats-server.ts)) gains:
+
+- `monitoring: boolean | number` — default `false`.
+- `startTimeoutMs: number` — default `30000`.
+
+`DEFAULT_NATS_SERVER_OPTIONS` adds `monitoring: false` and `startTimeoutMs: 30000`.
+`pickRuntimeOptions()` is extended to copy `monitoring` and `startTimeoutMs` from a
+config file when present (only when defined, matching the existing pattern).
+
+## 5. `start()` control flow
+
+1. Resolve options (defaults < config file < code), as today.
+2. Resolve the **client** port: explicit `port` or `await getFreePort()` — unchanged.
+   The client-port TOCTOU race is **not** addressed here.
+3. Resolve **monitoring**:
+   - disabled (`monitoring === false`): no monitoring args; `monitorPort` stays unset.
+   - enabled: `monitorPort = (typeof monitoring === 'number' ? monitoring : await getFreePort())`.
+4. Build spawn args:
+   - disabled: `['--addr', ip, '--port', String(port), ...args]` — **identical to today**.
+   - enabled: `['--addr', ip, '--port', String(port), '-m', String(monitorPort), ...args]`
+     (`-m` before user `...args` so explicit user args keep precedence).
+5. `spawn(binPath, args, { stdio: 'pipe' })`; record `host`, `port`, and `monitorPort`.
+   Keep `stdout.resume()` (drain) as today.
+6. Arm readiness with a single shared timeout/abort:
+   - Create an `AbortController` and an `unref()`'d timer for `startTimeoutMs`.
+   - On timer expiry **if not yet ready**: `controller.abort()`, `child.kill()`,
+     `this.process = undefined`, `reject(new Error('NATS server did not become ready
+     within <ms>ms'))` (include a short buffered stderr tail when available).
+   - **Readiness signal:**
+     - monitoring **enabled** → `await waitForHealthz(healthzUrl, { signal, intervalMs: 50 })`;
+       resolve on first `200`. The stderr scan is **not** used for readiness in this mode
+       (still logged when `verbose`).
+     - monitoring **disabled** → resolve when a stderr chunk includes `Server is ready`
+       (current behavior), now bounded by the timeout.
+   - `error` event (spawn failure) → reject if not ready (unchanged).
+   - `close` before ready → reject `NATS server exited before becoming ready` (unchanged).
+   - **All** settlement paths (resolve, timeout, error, close) `clearTimeout` and
+     `controller.abort()` so no timer or poll outlives `start()`.
+7. On ready: `resolve(this)` then `this.process?.unref()` (unchanged; the orphan-cleanup
+   fix is a separate step).
+
+`healthzUrl` host = `ip === '0.0.0.0' ? '127.0.0.1' : ip` (poll a connectable host when
+bound to the wildcard address); port = `monitorPort`; path = `/healthz`.
+
+## 6. New unit: `src/utils/wait-for-healthz.ts`
+
+A small, isolated, independently testable poller — keeps `start()` thin.
+
+```ts
+export interface WaitForHealthzOptions {
+  intervalMs?: number;   // default 50
+  signal?: AbortSignal;  // abort to stop polling (driven by start()'s timeout)
+}
+
+// Polls GET <url> using node:http (no proxy — the target is local). Resolves on the
+// first 2xx response. Connection-refused / non-2xx / parse errors before readiness are
+// swallowed and retried after intervalMs. Rejects only when the signal aborts.
+export async function waitForHealthz(
+  url: string,
+  options?: WaitForHealthzOptions,
+): Promise<void>;
+```
+
+Uses `node:http` (not `make-fetch-happen`) — the endpoint is always local, so no proxy
+handling is needed and no new heavy dependency is pulled onto the start path. Exported
+from `src/utils/index.ts`.
+
+## 7. Error handling
+
+- **Timeout:** child killed, `this.process` nulled, reject with a clear message (+ stderr
+  tail). No timer or poll leaks past `start()`.
+- **healthz polling:** `ECONNREFUSED` / transient errors / non-2xx before ready are
+  expected (server still coming up) → retry until the shared timeout aborts.
+- **Explicit monitoring port already in use:** `nats-server` exits non-zero before ready
+  → caught by the existing `close`-before-ready rejection.
+
+## 8. Backward compatibility
+
+- Monitoring is **off by default**, so spawn args and readiness for existing users are
+  unchanged except that `start()` is now bounded by `startTimeoutMs`.
+- The existing test asserting exact spawn args `['--addr','127.0.0.1','--port','4222']`
+  (`src/nats-server.spec.ts:249-253`) stays valid because monitoring-off appends nothing.
+
+## 9. Testing (TDD)
+
+Deterministic unit tests (mock `child_process.spawn` with a fake child, per the existing
+`makeFloodingChild` pattern) plus real-binary integration coverage:
+
+1. **Builder setters** return `this` and are chainable; last-call-wins for
+   `enableMonitoring`/`disableMonitoring`/`setMonitoringPort`.
+2. **Default (monitoring off):** `getMonitoringUrl()` → `undefined`; start resolves via the
+   stderr path; spawn args unchanged (existing flood test continues to pass).
+3. **`waitForHealthz` unit:** resolves on a fake local `http` server returning `200` on
+   `/healthz`; retries through `ECONNREFUSED`/non-2xx; rejects when its `AbortSignal` aborts.
+4. **Monitoring enabled (mocked spawn + fake healthz server on an explicit port):**
+   `setMonitoringPort(p)` → `start()` resolves via healthz; `getMonitoringUrl()` ===
+   `http://127.0.0.1:p`; spawn args include `-m <p>`.
+5. **Monitoring enabled (integration, real binary):** `enableMonitoring()` → `start()`;
+   `GET getMonitoringUrl()+'/healthz'` → `200`; pub/sub round-trip works; `stop()`.
+6. **Start timeout:** fake child that never signals readiness (no `Server is ready`, and —
+   for the monitoring case — no healthz server) → `start()` rejects within
+   `startTimeoutMs` (tests use a small value, e.g. 200ms) and the child is killed.
+7. **Config file:** `monitoring`/`startTimeoutMs` from a config file are honored; explicit
+   code options override the file.
+
+## 10. Files touched
+
+- [src/nats-server.ts](../../../src/nats-server.ts) — options/defaults, `pickRuntimeOptions`,
+  `start()` flow, `getMonitoringUrl()`, `monitorPort` field.
+- [src/nats-server.builder.ts](../../../src/nats-server.builder.ts) — `enableMonitoring`,
+  `disableMonitoring`, `setMonitoringPort`, `setStartTimeout`.
+- [src/utils/get-project-config.ts](../../../src/utils/get-project-config.ts) — config type
+  fields `monitoring`, `startTimeoutMs`.
+- **new** [src/utils/wait-for-healthz.ts](../../../src/utils/wait-for-healthz.ts) + export in
+  `src/utils/index.ts`.
+- Tests: `src/nats-server.spec.ts`, `src/nats-server.builder.spec.ts`,
+  `src/nats-server.project-config.spec.ts`, and a new `src/utils/wait-for-healthz.spec.ts`.
+- `README.md` — a short "Monitoring" subsection (`enableMonitoring()` / `getMonitoringUrl()`)
+  and a note on `setStartTimeout()`.
+
+## 11. Out of scope (future steps)
+
+- Client-port TOCTOU race (use `--port -1` / `--ports_file_dir` + `/varz`).
+- Orphan-process cleanup on abnormal exit (exit/SIGINT/SIGTERM handlers).
+- `stop()` timeout + SIGKILL escalation.
+- First-class JetStream / cluster / auth / TLS helpers.

--- a/src/nats-server.builder.spec.ts
+++ b/src/nats-server.builder.spec.ts
@@ -58,4 +58,38 @@ describe(NatsServerBuilder.name, () => {
     const server = builder.build();
     expect((server as any).options.logger).toBe(logger);
   });
+
+  it(`Should enable monitoring`, () => {
+    const server = NatsServerBuilder.create().enableMonitoring().build();
+    expect((server as any).options.monitoring).toBe(true);
+  });
+
+  it(`Should disable monitoring`, () => {
+    const server = NatsServerBuilder.create().disableMonitoring().build();
+    expect((server as any).options.monitoring).toBe(false);
+  });
+
+  it(`Should set an explicit monitoring port`, () => {
+    const server = NatsServerBuilder.create().setMonitoringPort(8222).build();
+    expect((server as any).options.monitoring).toBe(8222);
+  });
+
+  it(`Should apply last-call-wins across monitoring setters`, () => {
+    const a = NatsServerBuilder.create()
+      .enableMonitoring()
+      .setMonitoringPort(8222)
+      .build();
+    expect((a as any).options.monitoring).toBe(8222);
+
+    const b = NatsServerBuilder.create()
+      .setMonitoringPort(8222)
+      .disableMonitoring()
+      .build();
+    expect((b as any).options.monitoring).toBe(false);
+  });
+
+  it(`Should set the start timeout`, () => {
+    const server = NatsServerBuilder.create().setStartTimeout(5000).build();
+    expect((server as any).options.startTimeoutMs).toBe(5000);
+  });
 });

--- a/src/nats-server.builder.ts
+++ b/src/nats-server.builder.ts
@@ -41,6 +41,26 @@ export class NatsServerBuilder {
     return this;
   }
 
+  enableMonitoring(): this {
+    this.options = { ...this.options, monitoring: true };
+    return this;
+  }
+
+  disableMonitoring(): this {
+    this.options = { ...this.options, monitoring: false };
+    return this;
+  }
+
+  setMonitoringPort(port: number): this {
+    this.options = { ...this.options, monitoring: port };
+    return this;
+  }
+
+  setStartTimeout(ms: number): this {
+    this.options = { ...this.options, startTimeoutMs: ms };
+    return this;
+  }
+
   setLogger(logger: Logger): this {
     this.options = { ...this.options, logger };
     return this;

--- a/src/nats-server.project-config.spec.ts
+++ b/src/nats-server.project-config.spec.ts
@@ -1,6 +1,8 @@
 import child_process from 'child_process';
 import type { ChildProcessWithoutNullStreams } from 'child_process';
 import { EventEmitter } from 'events';
+import http from 'http';
+import type { AddressInfo } from 'net';
 import { PassThrough } from 'stream';
 import { NatsServer, type Logger } from './nats-server';
 import { NatsServerBuilder } from './nats-server.builder';
@@ -51,6 +53,31 @@ function makeFakeChild(): ChildProcessWithoutNullStreams {
 
   setImmediate(() => {
     stderr.write(`[INF] Server is ready\n`);
+  });
+
+  return child;
+}
+
+function makeNeverReadyChild(): ChildProcessWithoutNullStreams {
+  const child = new EventEmitter() as unknown as ChildProcessWithoutNullStreams;
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+
+  Object.assign(child, {
+    stdout,
+    stderr,
+    exitCode: null,
+    signalCode: null,
+    unref: () => {
+      // no-op
+    },
+    kill: () => {
+      Object.assign(child, { exitCode: 0 });
+      stdout.end();
+      stderr.end();
+      queueMicrotask(() => child.emit(`close`, 0, null));
+      return true;
+    },
   });
 
   return child;
@@ -218,5 +245,49 @@ describe(`${NatsServer.name} project-config runtime options`, () => {
     );
 
     await server.stop();
+  });
+
+  it(`Should enable monitoring from the project config`, async () => {
+    const healthServer = http.createServer((_req, res) => {
+      res.writeHead(200);
+      res.end(`{"status":"ok"}`);
+    });
+    await new Promise<void>((resolve) => {
+      healthServer.listen(0, `127.0.0.1`, resolve);
+    });
+    const monitorPort = (healthServer.address() as AddressInfo).port;
+
+    getProjectConfigMock.mockResolvedValue(
+      makeProjectConfig({ verbose: false, monitoring: monitorPort }),
+    );
+
+    const server = NatsServerBuilder.create().setLogger(makeLogger()).build();
+
+    await server.start();
+
+    expect(spawnSpy).toHaveBeenCalledWith(
+      `config-bin`,
+      [`--addr`, `127.0.0.1`, `--port`, `23456`, `-m`, String(monitorPort)],
+      { stdio: `pipe` },
+    );
+    expect(server.getMonitoringUrl()).toBe(`http://127.0.0.1:${monitorPort}`);
+
+    await server.stop();
+    await new Promise<void>((resolve) => {
+      healthServer.close(() => {
+        resolve();
+      });
+    });
+  });
+
+  it(`Should fail fast using startTimeoutMs from the project config`, async () => {
+    spawnSpy.mockImplementation(() => makeNeverReadyChild());
+    getProjectConfigMock.mockResolvedValue(
+      makeProjectConfig({ verbose: false, startTimeoutMs: 120 }),
+    );
+
+    const server = NatsServerBuilder.create().setLogger(makeLogger()).build();
+
+    await expect(server.start()).rejects.toThrow(/did not become ready/);
   });
 });

--- a/src/nats-server.spec.ts
+++ b/src/nats-server.spec.ts
@@ -3,7 +3,11 @@ import type { ChildProcessWithoutNullStreams } from 'child_process';
 import { EventEmitter } from 'events';
 import http from 'http';
 import { PassThrough, Readable } from 'stream';
-import { DEFAULT_NATS_SERVER_OPTIONS, NatsServer } from './nats-server';
+import {
+  DEFAULT_NATS_SERVER_OPTIONS,
+  NatsServer,
+  buildHealthzUrl,
+} from './nats-server';
 import { NatsServerBuilder } from './nats-server.builder';
 import { getFreePort } from './utils';
 import { connect, StringCodec } from 'nats';
@@ -512,5 +516,62 @@ describe(NatsServer.name, () => {
     } finally {
       await server.stop();
     }
+  });
+
+  it(`keeps a multibyte stderr char intact when split across chunks`, async () => {
+    const child = makeSilentChild();
+    const emojiBytes = Buffer.from(`😀`, `utf8`); // 4 UTF-8 bytes
+
+    const spawnSpy = jest
+      .spyOn(child_process, `spawn`)
+      .mockImplementation(() => {
+        setImmediate(() => {
+          const stderr = child.stderr as unknown as PassThrough;
+          stderr.write(Buffer.from(`[ERR] `, `utf8`));
+          // Split the 4-byte sequence across two separate `data` events.
+          stderr.write(emojiBytes.subarray(0, 2));
+          stderr.write(emojiBytes.subarray(2));
+        });
+        return child;
+      });
+
+    try {
+      const server = NatsServerBuilder.create()
+        .setVerbose(false)
+        .setBinPath(`fake-nats-server`)
+        .setStartTimeout(150)
+        .build();
+
+      // The captured tail must contain the intact emoji, not the U+FFFD
+      // replacement characters a per-chunk decode would produce.
+      await expect(server.start()).rejects.toThrow(/😀/);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+});
+
+describe(`buildHealthzUrl`, () => {
+  it(`uses the bind host for a normal IPv4 address`, () => {
+    expect(buildHealthzUrl(`127.0.0.1`, 8222)).toBe(
+      `http://127.0.0.1:8222/healthz`,
+    );
+  });
+
+  it(`probes loopback for the IPv4 wildcard`, () => {
+    expect(buildHealthzUrl(`0.0.0.0`, 8222)).toBe(
+      `http://127.0.0.1:8222/healthz`,
+    );
+  });
+
+  it(`probes ::1 and brackets the IPv6 wildcard`, () => {
+    expect(buildHealthzUrl(`::`, 8222)).toBe(`http://[::1]:8222/healthz`);
+  });
+
+  it(`brackets IPv6 literals`, () => {
+    expect(buildHealthzUrl(`::1`, 8222)).toBe(`http://[::1]:8222/healthz`);
+    expect(buildHealthzUrl(`fe80::1`, 9000)).toBe(
+      `http://[fe80::1]:9000/healthz`,
+    );
   });
 });

--- a/src/nats-server.spec.ts
+++ b/src/nats-server.spec.ts
@@ -381,6 +381,77 @@ describe(NatsServer.name, () => {
     }
   });
 
+  it(`Should include recent stderr in the timeout error`, async () => {
+    const child = makeSilentChild();
+    const spawnSpy = jest
+      .spyOn(child_process, `spawn`)
+      .mockImplementation(() => {
+        setImmediate(() => {
+          (child.stderr as unknown as PassThrough).write(
+            `[ERR] boom happened\n`,
+          );
+        });
+        return child;
+      });
+
+    try {
+      const server = NatsServerBuilder.create()
+        .setVerbose(false)
+        .setBinPath(`fake-nats-server`)
+        .setStartTimeout(150)
+        .build();
+
+      await expect(server.start()).rejects.toThrow(/boom happened/);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it(`Should poll 127.0.0.1 for /healthz when bound to 0.0.0.0`, async () => {
+    const monitorPort = await getFreePort();
+    const healthServer = http.createServer((req, res) => {
+      if (req.url === `/healthz`) {
+        res.writeHead(200);
+        res.end(`{"status":"ok"}`);
+      } else {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+    await new Promise<void>((resolve) => {
+      healthServer.listen(monitorPort, `127.0.0.1`, resolve);
+    });
+
+    const spawnSpy = jest
+      .spyOn(child_process, `spawn`)
+      .mockImplementation(() => makeSilentChild());
+
+    try {
+      const server = NatsServerBuilder.create()
+        .setVerbose(false)
+        .setBinPath(`fake-nats-server`)
+        .setIp(`0.0.0.0`)
+        .setPort(45340)
+        .setMonitoringPort(monitorPort)
+        .build();
+
+      // The healthz server is bound to 127.0.0.1 only; start() resolving proves
+      // the poll targeted 127.0.0.1 rather than 0.0.0.0. The public URL mirrors
+      // getUrl()'s convention and reflects the configured bind host.
+      await withTimeout(server.start(), 5000, `0.0.0.0 monitoring start()`);
+      expect(server.getMonitoringUrl()).toBe(`http://0.0.0.0:${monitorPort}`);
+
+      await server.stop();
+    } finally {
+      spawnSpy.mockRestore();
+      await new Promise<void>((resolve) => {
+        healthServer.close(() => {
+          resolve();
+        });
+      });
+    }
+  });
+
   it(`Should expose a working /healthz endpoint with the real server`, async () => {
     const server = await NatsServerBuilder.create()
       .setVerbose(false)

--- a/src/nats-server.spec.ts
+++ b/src/nats-server.spec.ts
@@ -1,6 +1,7 @@
 import child_process from 'child_process';
 import type { ChildProcessWithoutNullStreams } from 'child_process';
 import { EventEmitter } from 'events';
+import http from 'http';
 import { PassThrough, Readable } from 'stream';
 import { DEFAULT_NATS_SERVER_OPTIONS, NatsServer } from './nats-server';
 import { NatsServerBuilder } from './nats-server.builder';
@@ -44,6 +45,36 @@ function makeFloodingChild(): ChildProcessWithoutNullStreams {
   stdout.push(null);
   stdout.once(`end`, () => {
     stderr.write(`[INF] Server is ready\n`);
+  });
+
+  return child;
+}
+
+/**
+ * A fake child that spawns successfully and stays alive but NEVER writes a
+ * readiness line. Used to exercise the start timeout and the healthz path,
+ * where readiness must come from somewhere other than stderr.
+ */
+function makeSilentChild(): ChildProcessWithoutNullStreams {
+  const child = new EventEmitter() as unknown as ChildProcessWithoutNullStreams;
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+
+  Object.assign(child, {
+    stdout,
+    stderr,
+    exitCode: null,
+    signalCode: null,
+    unref: () => {
+      // no-op
+    },
+    kill: () => {
+      Object.assign(child, { exitCode: 0 });
+      stdout.end();
+      stderr.end();
+      queueMicrotask(() => child.emit(`close`, 0, null));
+      return true;
+    },
   });
 
   return child;
@@ -255,6 +286,106 @@ describe(NatsServer.name, () => {
       await server.stop();
     } finally {
       spawnSpy.mockRestore();
+    }
+  });
+
+  it(`Should reject start() if the server never becomes ready within the timeout`, async () => {
+    const spawnSpy = jest
+      .spyOn(child_process, `spawn`)
+      .mockImplementation(() => makeSilentChild());
+
+    try {
+      const server = NatsServerBuilder.create()
+        .setVerbose(false)
+        .setBinPath(`fake-nats-server`)
+        .setStartTimeout(150)
+        .build();
+
+      await expect(server.start()).rejects.toThrow(/did not become ready/);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it(`Should return undefined from getMonitoringUrl when monitoring is disabled`, () => {
+    const server = NatsServerBuilder.create().build();
+    expect(server.getMonitoringUrl()).toBeUndefined();
+  });
+
+  it(`Should become ready via /healthz and expose getMonitoringUrl when monitoring is enabled`, async () => {
+    const monitorPort = await getFreePort();
+    const healthServer = http.createServer((req, res) => {
+      if (req.url === `/healthz`) {
+        res.writeHead(200);
+        res.end(`{"status":"ok"}`);
+      } else {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+    await new Promise<void>((resolve) => {
+      healthServer.listen(monitorPort, `127.0.0.1`, resolve);
+    });
+
+    const spawnSpy = jest
+      .spyOn(child_process, `spawn`)
+      .mockImplementation(() => makeSilentChild());
+
+    try {
+      const server = NatsServerBuilder.create()
+        .setVerbose(false)
+        .setBinPath(`fake-nats-server`)
+        .setIp(`127.0.0.1`)
+        .setPort(45330)
+        .setMonitoringPort(monitorPort)
+        .build();
+
+      await withTimeout(server.start(), 5000, `monitoring start()`);
+
+      expect(server.getMonitoringUrl()).toBe(`http://127.0.0.1:${monitorPort}`);
+      expect(spawnSpy).toHaveBeenCalledWith(
+        `fake-nats-server`,
+        [`--addr`, `127.0.0.1`, `--port`, `45330`, `-m`, String(monitorPort)],
+        { stdio: `pipe` },
+      );
+
+      await server.stop();
+    } finally {
+      spawnSpy.mockRestore();
+      await new Promise<void>((resolve) => {
+        healthServer.close(() => {
+          resolve();
+        });
+      });
+    }
+  });
+
+  it(`Should expose a working /healthz endpoint with the real server`, async () => {
+    const server = await NatsServerBuilder.create()
+      .setVerbose(false)
+      .enableMonitoring()
+      .build()
+      .start();
+
+    try {
+      const url = server.getMonitoringUrl();
+      expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+
+      const status = await new Promise<number>((resolve, reject) => {
+        http
+          .get(`${url as string}/healthz`, (res) => {
+            res.resume();
+            resolve(res.statusCode ?? 0);
+          })
+          .on(`error`, reject);
+      });
+      expect(status).toBe(200);
+
+      const nc = await connect({ servers: server.getUrl() });
+      expect(nc.isClosed()).toBe(false);
+      await nc.close();
+    } finally {
+      await server.stop();
     }
   });
 });

--- a/src/nats-server.spec.ts
+++ b/src/nats-server.spec.ts
@@ -360,6 +360,27 @@ describe(NatsServer.name, () => {
     }
   });
 
+  it(`Should return undefined from getMonitoringUrl after a failed start with monitoring enabled`, async () => {
+    const monitorPort = await getFreePort(); // nothing serves /healthz here
+    const spawnSpy = jest
+      .spyOn(child_process, `spawn`)
+      .mockImplementation(() => makeSilentChild());
+
+    try {
+      const server = NatsServerBuilder.create()
+        .setVerbose(false)
+        .setBinPath(`fake-nats-server`)
+        .setMonitoringPort(monitorPort)
+        .setStartTimeout(150)
+        .build();
+
+      await expect(server.start()).rejects.toThrow(/did not become ready/);
+      expect(server.getMonitoringUrl()).toBeUndefined();
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
   it(`Should expose a working /healthz endpoint with the real server`, async () => {
     const server = await NatsServerBuilder.create()
       .setVerbose(false)

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -133,7 +133,7 @@ export class NatsServer {
 
     this.host = ip;
     this.port = port;
-    this.monitorPort = monitorPort;
+    this.monitorPort = undefined;
 
     const spawnArgs =
       monitorPort !== undefined
@@ -186,6 +186,7 @@ export class NatsServer {
         if (verbose) {
           logger.log(`NATS server is ready!`);
         }
+        this.monitorPort = monitorPort;
         resolve(this);
         child.unref();
       };

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -19,6 +19,10 @@ export interface NatsServerOptions {
   ip: string;
   logger: Logger;
   binPath?: string;
+  /** HTTP monitoring port: `false` disables it, `true` picks a free port, a number uses that port. */
+  monitoring: boolean | number;
+  /** How long start() waits for readiness before failing, in milliseconds. */
+  startTimeoutMs: number;
 }
 
 export const DEFAULT_NATS_SERVER_OPTIONS = {
@@ -29,6 +33,8 @@ export const DEFAULT_NATS_SERVER_OPTIONS = {
   ip: `127.0.0.1`,
   args: [],
   logger: console,
+  monitoring: false,
+  startTimeoutMs: 30000,
 } satisfies NatsServerOptions;
 
 /**
@@ -55,6 +61,12 @@ function pickRuntimeOptions(
   }
   if (config.binPath !== undefined) {
     runtime.binPath = config.binPath;
+  }
+  if (config.monitoring !== undefined) {
+    runtime.monitoring = config.monitoring;
+  }
+  if (config.startTimeoutMs !== undefined) {
+    runtime.startTimeoutMs = config.startTimeoutMs;
   }
 
   return runtime;

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -3,6 +3,7 @@ import {
   getFreePort,
   getProjectConfig,
   getProjectPath,
+  waitForHealthz,
   type NatsMemoryServerConfig,
 } from './utils';
 export interface Logger {
@@ -77,6 +78,7 @@ export class NatsServer {
 
   private host!: string;
   private port!: number;
+  private monitorPort?: number;
 
   /** The options start() actually ran with, after merging in the defaults
    * and the project config; used by stop() so both ends of the lifecycle
@@ -86,15 +88,8 @@ export class NatsServer {
   constructor(private readonly options: Partial<NatsServerOptions> = {}) {}
 
   async start(): Promise<this> {
-    // getProjectConfig memoizes per project path (and no longer caches a
-    // rejection), so calling it directly each start() is both cheap and
-    // recoverable — no separate static promise cache is needed here.
     const projectConfig = await getProjectConfig(getProjectPath());
 
-    // Precedence: built-in defaults < project config file < options passed
-    // explicitly to the builder/constructor. Plain spreads keep an
-    // explicitly-set `undefined` overriding the config (e.g. a deliberate
-    // `{ binPath: undefined }` must not silently fall back).
     const config: NatsServerOptions = {
       ...DEFAULT_NATS_SERVER_OPTIONS,
       ...pickRuntimeOptions(projectConfig),
@@ -114,53 +109,137 @@ export class NatsServer {
       return this;
     }
 
-    const { args, ip, port = await getFreePort(), binPath } = config;
+    const {
+      args,
+      ip,
+      port = await getFreePort(),
+      binPath,
+      monitoring,
+      startTimeoutMs,
+    } = config;
 
     if (binPath == null) {
       throw new Error(`Could not resolve a binPath for the NATS server binary`);
     }
 
+    // Resolve the monitoring port. `undefined` means monitoring is disabled; a
+    // free port is allocated when monitoring is enabled without an explicit one.
+    const monitorPort =
+      monitoring === false
+        ? undefined
+        : typeof monitoring === `number`
+        ? monitoring
+        : await getFreePort();
+
+    this.host = ip;
+    this.port = port;
+    this.monitorPort = monitorPort;
+
+    const spawnArgs =
+      monitorPort !== undefined
+        ? [
+            `--addr`,
+            ip,
+            `--port`,
+            port.toString(),
+            `-m`,
+            monitorPort.toString(),
+            ...args,
+          ]
+        : [`--addr`, ip, `--port`, port.toString(), ...args];
+
     return await new Promise((resolve, reject) => {
-      this.process = child_process.spawn(
-        binPath,
-        [`--addr`, ip, `--port`, port.toString(), ...args],
-        { stdio: `pipe` },
-      );
+      const child = child_process.spawn(binPath, spawnArgs, { stdio: `pipe` });
+      this.process = child;
 
-      this.host = ip;
-      this.port = port;
-
-      // Drain stdout so a child that writes heavily to stdout (e.g. `--log
-      // /dev/stdout`) can't deadlock by filling the OS pipe buffer while we
-      // wait for the readiness line on stderr. nats-server itself logs to
-      // stderr, but we don't control what a custom binPath prints. We don't
-      // need stdout's contents, so just let it flow and discard.
-      this.process.stdout.resume();
+      // Drain stdout so a child that writes heavily to stdout can't deadlock by
+      // filling the OS pipe buffer while we wait for readiness.
+      child.stdout.resume();
 
       let isReady = false;
+      let settled = false;
 
-      this.process.once(`error`, (err) => {
+      // A single controller + timer bounds the whole readiness wait and stops
+      // the healthz poller. Cleared/aborted in every settlement path so nothing
+      // outlives start().
+      const controller = new AbortController();
+
+      const settleReject = (error: Error): void => {
+        clearTimeout(timer);
+        controller.abort();
+        if (settled) {
+          return;
+        }
+        settled = true;
+        this.process = undefined;
+        reject(error);
+      };
+
+      const markReady = (): void => {
+        if (settled) {
+          return;
+        }
+        isReady = true;
+        settled = true;
+        clearTimeout(timer);
+        controller.abort();
+        if (verbose) {
+          logger.log(`NATS server is ready!`);
+        }
+        resolve(this);
+        child.unref();
+      };
+
+      const timer = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+        // Kill the child we could not confirm ready, then fail loudly.
+        child.kill();
+        if (verbose) {
+          logger.warn(
+            `NATS server did not become ready within ${startTimeoutMs}ms`,
+          );
+        }
+        settleReject(
+          new Error(
+            `NATS server did not become ready within ${startTimeoutMs}ms`,
+          ),
+        );
+      }, startTimeoutMs);
+      timer.unref();
+
+      child.once(`error`, (err) => {
         if (verbose) {
           logger.error(`NATS server error:`, err);
         }
-
-        // Only fail the start Promise if we never became ready; a transient
-        // error after readiness must not tear down a running server's handle.
-        if (!isReady) {
-          this.process = undefined;
-          reject(err);
-        }
+        // After readiness, settleReject() is a no-op (settled) and leaves the
+        // running handle intact — a transient post-ready error must not tear it
+        // down. Before readiness it rejects the start Promise.
+        settleReject(err);
       });
 
-      this.process.stderr.on(`data`, (data: unknown) => {
-        // Once ready, non-verbose mode has nothing left to do on this stream,
-        // so skip the work entirely for high-volume logs.
+      // When monitoring is enabled, readiness is decided by the HTTP monitoring
+      // endpoint — deterministic and independent of log text.
+      if (monitorPort !== undefined) {
+        const healthHost = ip === `0.0.0.0` ? `127.0.0.1` : ip;
+        const healthUrl = `http://${healthHost}:${monitorPort}/healthz`;
+        void waitForHealthz(healthUrl, { signal: controller.signal })
+          .then(() => {
+            markReady();
+          })
+          .catch(() => {
+            // Aborted by the timeout/error/close path, which has already
+            // settled the Promise; nothing to do here.
+          });
+      }
+
+      child.stderr.on(`data`, (data: unknown) => {
+        // Once ready, non-verbose mode has nothing left to do on this stream.
         if (isReady && !verbose) {
           return;
         }
 
-        // Only allocate a string when we actually need it (verbose logging or
-        // the readiness check on a non-Buffer chunk).
         let dataStr: string | undefined;
         if (Buffer.isBuffer(data)) {
           if (verbose) {
@@ -175,37 +254,31 @@ export class NatsServer {
           logger.log(dataStr);
         }
 
-        if (!isReady) {
+        // Stderr is the readiness signal only when monitoring is disabled.
+        if (monitorPort === undefined && !isReady) {
           const ready = Buffer.isBuffer(data)
             ? data.includes(`Server is ready`)
             : dataStr?.includes(`Server is ready`) === true;
 
           if (ready) {
-            isReady = true;
-            if (verbose) {
-              logger.log(`NATS server is ready!`);
-            }
-            resolve(this);
-            this.process?.unref();
+            markReady();
           }
         }
       });
 
-      this.process.once(`close`, (code) => {
+      child.once(`close`, (code) => {
         // The child has exited: clear the handle so a later stop() does not
-        // kill() a dead process (which never re-emits `close`, hanging stop())
-        // and so start() can spawn a fresh server on a subsequent call.
+        // kill() a dead process and so start() can spawn a fresh server later.
         this.process = undefined;
+        clearTimeout(timer);
+        controller.abort();
 
         if (verbose) {
           logger.log(`NATS server was stop!`);
         }
 
-        // Exiting before the readiness signal is always a failure regardless of
-        // the exit code (nats-server exits 0 on `--help`, 1 on a port conflict).
-        // After readiness the start Promise is already settled, so this branch
-        // is a no-op for the normal shutdown path.
-        if (!isReady) {
+        // Exiting before readiness is always a failure regardless of exit code.
+        if (!settled) {
           const message = `NATS server exited before becoming ready${
             code !== null ? ` (exit code: ${code})` : ``
           }`;
@@ -214,7 +287,7 @@ export class NatsServer {
             logger.warn(message, code);
           }
 
-          reject(new Error(message));
+          settleReject(new Error(message));
         }
       });
     });
@@ -222,6 +295,13 @@ export class NatsServer {
 
   public getUrl(): string {
     return `nats://${this.host}:${this.port}`;
+  }
+
+  public getMonitoringUrl(): string | undefined {
+    if (this.monitorPort === undefined) {
+      return undefined;
+    }
+    return `http://${this.host}:${this.monitorPort}`;
   }
 
   public getHost(): string {

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -158,6 +158,8 @@ export class NatsServer {
 
       let isReady = false;
       let settled = false;
+      let stderrTail = ``;
+      const MAX_STDERR_TAIL = 2000;
 
       // A single controller + timer bounds the whole readiness wait and stops
       // the healthz poller. Cleared/aborted in every settlement path so nothing
@@ -202,9 +204,11 @@ export class NatsServer {
             `NATS server did not become ready within ${startTimeoutMs}ms`,
           );
         }
+        const tail = stderrTail.trim();
         settleReject(
           new Error(
-            `NATS server did not become ready within ${startTimeoutMs}ms`,
+            `NATS server did not become ready within ${startTimeoutMs}ms` +
+              (tail !== `` ? `. Last stderr: ${tail}` : ``),
           ),
         );
       }, startTimeoutMs);
@@ -236,19 +240,23 @@ export class NatsServer {
       }
 
       child.stderr.on(`data`, (data: unknown) => {
-        // Once ready, non-verbose mode has nothing left to do on this stream.
-        if (isReady && !verbose) {
+        // Once settled, non-verbose mode has nothing left to do on this stream.
+        if (settled && !verbose) {
           return;
         }
 
         let dataStr: string | undefined;
         if (Buffer.isBuffer(data)) {
-          if (verbose) {
-            dataStr = data.toString();
-          }
-        } else {
+          dataStr = data.toString();
+        } else if (data != null) {
           // eslint-disable-next-line @typescript-eslint/no-base-to-string
-          dataStr = data?.toString();
+          dataStr = String(data);
+        }
+
+        // Keep a short rolling tail of stderr before readiness so a failed
+        // start can report what nats-server actually printed.
+        if (!settled && dataStr != null && dataStr !== ``) {
+          stderrTail = (stderrTail + dataStr).slice(-MAX_STDERR_TAIL);
         }
 
         if (verbose && dataStr != null) {
@@ -256,12 +264,8 @@ export class NatsServer {
         }
 
         // Stderr is the readiness signal only when monitoring is disabled.
-        if (monitorPort === undefined && !isReady) {
-          const ready = Buffer.isBuffer(data)
-            ? data.includes(`Server is ready`)
-            : dataStr?.includes(`Server is ready`) === true;
-
-          if (ready) {
+        if (monitorPort === undefined && !isReady && dataStr != null) {
+          if (dataStr.includes(`Server is ready`)) {
             markReady();
           }
         }
@@ -280,9 +284,10 @@ export class NatsServer {
 
         // Exiting before readiness is always a failure regardless of exit code.
         if (!settled) {
+          const tail = stderrTail.trim();
           const message = `NATS server exited before becoming ready${
             code !== null ? ` (exit code: ${code})` : ``
-          }`;
+          }${tail !== `` ? `. Last stderr: ${tail}` : ``}`;
 
           if (verbose) {
             logger.warn(message, code);

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -1,4 +1,5 @@
 import child_process from 'child_process';
+import { StringDecoder } from 'string_decoder';
 import {
   getFreePort,
   getProjectConfig,
@@ -73,6 +74,29 @@ function pickRuntimeOptions(
   return runtime;
 }
 
+/**
+ * Builds the local `/healthz` probe URL for a server bound to `ip`. Wildcard
+ * binds are probed over loopback (`0.0.0.0` -> `127.0.0.1`, `::` -> `::1`), and
+ * IPv6 literals are wrapped in brackets so the URL is well-formed — otherwise
+ * `http.get` throws `ERR_INVALID_URL` and readiness can only fail by timeout.
+ */
+export function buildHealthzUrl(ip: string, monitorPort: number): string {
+  let host: string;
+  if (ip === `0.0.0.0` || ip === ``) {
+    host = `127.0.0.1`;
+  } else if (ip === `::` || ip === `[::]`) {
+    host = `::1`;
+  } else {
+    host = ip;
+  }
+
+  // An IPv6 literal (contains `:`) must be bracketed in a URL authority.
+  const authorityHost =
+    host.includes(`:`) && !host.startsWith(`[`) ? `[${host}]` : host;
+
+  return `http://${authorityHost}:${monitorPort}/healthz`;
+}
+
 export class NatsServer {
   private process?: child_process.ChildProcessWithoutNullStreams;
 
@@ -144,27 +168,42 @@ export class NatsServer {
     this.resolvedOptions = config;
 
     const { verbose, logger } = config;
-    const {
-      args,
-      ip,
-      port = await getFreePort(),
-      binPath,
-      monitoring,
-      startTimeoutMs,
-    } = config;
+    const { args, ip, binPath, monitoring, startTimeoutMs } = config;
 
     if (binPath == null) {
       throw new Error(`Could not resolve a binPath for the NATS server binary`);
     }
 
-    // Resolve the monitoring port. `undefined` means monitoring is disabled; a
-    // free port is allocated when monitoring is enabled without an explicit one.
+    // Resolve the client and monitoring ports so they can never collide.
+    // getFreePort releases each probe socket before returning, so two unguarded
+    // calls — or an auto port that happens to equal an explicit one — could
+    // yield the same number, and `--port X -m X` fails to bind. Exclude the
+    // explicit monitoring port when auto-allocating the client port, and the
+    // resolved client port when auto-allocating the monitoring port.
+    const explicitMonitorPort =
+      typeof monitoring === `number` ? monitoring : undefined;
+
+    const port =
+      config.port ??
+      (await getFreePort(
+        explicitMonitorPort !== undefined
+          ? new Set([explicitMonitorPort])
+          : undefined,
+      ));
+
+    // `undefined` means monitoring is disabled; a free port (distinct from the
+    // client port) is allocated when monitoring is enabled without an explicit
+    // one.
     const monitorPort =
       monitoring === false
         ? undefined
-        : typeof monitoring === `number`
-        ? monitoring
-        : await getFreePort();
+        : explicitMonitorPort ?? (await getFreePort(new Set([port])));
+
+    if (monitorPort !== undefined && monitorPort === port) {
+      throw new Error(
+        `NATS client port and monitoring port must differ (both ${port})`,
+      );
+    }
 
     this.host = ip;
     this.port = port;
@@ -195,6 +234,9 @@ export class NatsServer {
       let settled = false;
       let stderrTail = ``;
       const MAX_STDERR_TAIL = 2000;
+      // Decode stderr across chunk boundaries so a multibyte UTF-8 sequence
+      // split between two `data` events is not corrupted in the captured tail.
+      const stderrDecoder = new StringDecoder(`utf8`);
 
       // A single controller + timer bounds the whole readiness wait and stops
       // the healthz poller. Cleared/aborted in every settlement path so nothing
@@ -267,8 +309,7 @@ export class NatsServer {
       // When monitoring is enabled, readiness is decided by the HTTP monitoring
       // endpoint — deterministic and independent of log text.
       if (monitorPort !== undefined) {
-        const healthHost = ip === `0.0.0.0` ? `127.0.0.1` : ip;
-        const healthUrl = `http://${healthHost}:${monitorPort}/healthz`;
+        const healthUrl = buildHealthzUrl(ip, monitorPort);
         void waitForHealthz(healthUrl, { signal: controller.signal })
           .then(() => {
             markReady();
@@ -287,7 +328,7 @@ export class NatsServer {
 
         let dataStr: string | undefined;
         if (Buffer.isBuffer(data)) {
-          dataStr = data.toString();
+          dataStr = stderrDecoder.write(data);
         } else if (data != null) {
           // eslint-disable-next-line @typescript-eslint/no-base-to-string
           dataStr = String(data);

--- a/src/utils/get-free-port.spec.ts
+++ b/src/utils/get-free-port.spec.ts
@@ -1,0 +1,23 @@
+import { getFreePort } from './get-free-port';
+
+describe(`getFreePort`, () => {
+  it(`returns a usable TCP port number`, async () => {
+    const port = await getFreePort();
+    expect(port).toBeGreaterThan(0);
+    expect(port).toBeLessThan(65536);
+  });
+
+  it(`never returns a port in the exclude set`, async () => {
+    const first = await getFreePort();
+    // first is released again here, so a naive allocator could hand it back;
+    // the exclude set must prevent that.
+    const second = await getFreePort(new Set([first]));
+    expect(second).not.toBe(first);
+  });
+
+  it(`allocates distinct client and monitoring ports`, async () => {
+    const client = await getFreePort();
+    const monitor = await getFreePort(new Set([client]));
+    expect(monitor).not.toBe(client);
+  });
+});

--- a/src/utils/get-free-port.ts
+++ b/src/utils/get-free-port.ts
@@ -1,14 +1,41 @@
 import net from 'net';
 
-export async function getFreePort(): Promise<number> {
-  return await new Promise<number>((resolve) => {
+/** Binds an ephemeral port, reads it, releases it, and returns the number. */
+async function allocatePort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
     const srv = net.createServer();
+    srv.once(`error`, reject);
     srv.listen(0, () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const port = (srv.address() as any).port;
+      const address = srv.address();
+      const port =
+        address !== null && typeof address === `object` ? address.port : 0;
       srv.close(() => {
-        resolve(port);
+        if (port === 0) {
+          reject(new Error(`Failed to acquire a free port`));
+        } else {
+          resolve(port);
+        }
       });
     });
   });
+}
+
+/**
+ * Resolves a TCP port that is free right now. Pass `exclude` to avoid specific
+ * ports: getFreePort releases each probe socket before returning, so two
+ * back-to-back calls can otherwise hand back the same number — excluding an
+ * already-chosen port keeps, e.g., a monitoring port from colliding with the
+ * client port (`--port X -m X` would fail to bind).
+ */
+export async function getFreePort(
+  exclude: ReadonlySet<number> = new Set(),
+): Promise<number> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const port = await allocatePort();
+    if (!exclude.has(port)) {
+      return port;
+    }
+  }
+
+  throw new Error(`Could not find a free port outside the excluded set`);
 }

--- a/src/utils/get-project-config.ts
+++ b/src/utils/get-project-config.ts
@@ -106,6 +106,10 @@ export interface NatsMemoryServerConfig {
   verbose?: boolean;
   /** Runtime: extra CLI arguments passed to `nats-server`. Default: `[]`. */
   args?: string[];
+  /** Runtime: HTTP monitoring port. `false` (default) / `true` (free port) / number. */
+  monitoring?: boolean | number;
+  /** Runtime: readiness timeout in milliseconds. Default: `30000`. */
+  startTimeoutMs?: number;
 }
 
 const defaultConfig: NatsMemoryServerConfig = {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,3 +7,4 @@ export * from './get-arch';
 export * from './get-project-config';
 export * from './with-retry';
 export * from './verify-checksum';
+export * from './wait-for-healthz';

--- a/src/utils/wait-for-healthz.spec.ts
+++ b/src/utils/wait-for-healthz.spec.ts
@@ -1,0 +1,79 @@
+import http from 'http';
+import type { AddressInfo } from 'net';
+import { waitForHealthz } from './wait-for-healthz';
+
+async function startServer(
+  handler: http.RequestListener,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  const server = http.createServer(handler);
+  await new Promise<void>((resolve) => {
+    server.listen(0, `127.0.0.1`, resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/healthz`,
+    close: async () => {
+      await new Promise<void>((resolve) => {
+        server.close(() => {
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+describe(`waitForHealthz`, () => {
+  it(`resolves once the endpoint returns 200`, async () => {
+    const { url, close } = await startServer((_req, res) => {
+      res.writeHead(200);
+      res.end(`{"status":"ok"}`);
+    });
+    try {
+      await expect(
+        waitForHealthz(url, { intervalMs: 10 }),
+      ).resolves.toBeUndefined();
+    } finally {
+      await close();
+    }
+  });
+
+  it(`retries through non-2xx responses until one succeeds`, async () => {
+    let hits = 0;
+    const { url, close } = await startServer((_req, res) => {
+      hits += 1;
+      if (hits < 3) {
+        res.writeHead(503);
+        res.end(`not ready`);
+      } else {
+        res.writeHead(200);
+        res.end(`ok`);
+      }
+    });
+    try {
+      await expect(
+        waitForHealthz(url, { intervalMs: 10 }),
+      ).resolves.toBeUndefined();
+      expect(hits).toBeGreaterThanOrEqual(3);
+    } finally {
+      await close();
+    }
+  });
+
+  it(`rejects when the signal aborts`, async () => {
+    const { url, close } = await startServer((_req, res) => {
+      res.writeHead(503);
+      res.end(`never ready`);
+    });
+    const controller = new AbortController();
+    setTimeout(() => {
+      controller.abort();
+    }, 50);
+    try {
+      await expect(
+        waitForHealthz(url, { intervalMs: 10, signal: controller.signal }),
+      ).rejects.toThrow(/aborted/);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/src/utils/wait-for-healthz.ts
+++ b/src/utils/wait-for-healthz.ts
@@ -1,0 +1,69 @@
+import http from 'http';
+
+export interface WaitForHealthzOptions {
+  /** Delay between poll attempts in milliseconds. Default: 50. */
+  intervalMs?: number;
+  /** Abort to stop polling; the returned promise rejects when aborted. */
+  signal?: AbortSignal;
+}
+
+const DEFAULT_INTERVAL_MS = 50;
+
+/** A single GET. Resolves true on a 2xx response, false on any error/non-2xx. */
+async function probeOnce(url: string, signal?: AbortSignal): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const request = http.get(url, { signal }, (response) => {
+      const status = response.statusCode ?? 0;
+      response.resume(); // drain so the socket frees promptly
+      resolve(status >= 200 && status < 300);
+    });
+    request.on(`error`, () => {
+      resolve(false);
+    });
+  });
+}
+
+async function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(new Error(`waitForHealthz aborted`));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener(`abort`, onAbort);
+      resolve();
+    }, ms);
+    if (signal != null) {
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      signal.addEventListener(`abort`, onAbort, { once: true });
+    }
+  });
+}
+
+/**
+ * Polls `GET <url>` until it returns a 2xx response, then resolves. Connection
+ * errors and non-2xx responses (the server is still coming up) are retried
+ * after `intervalMs`. Rejects only when `signal` aborts. Uses node:http — the
+ * target is always local, so no proxy handling is needed.
+ */
+export async function waitForHealthz(
+  url: string,
+  options: WaitForHealthzOptions = {},
+): Promise<void> {
+  const { intervalMs = DEFAULT_INTERVAL_MS, signal } = options;
+
+  for (;;) {
+    if (signal?.aborted === true) {
+      throw new Error(`waitForHealthz aborted`);
+    }
+
+    if (await probeOnce(url, signal)) {
+      return;
+    }
+
+    await delay(intervalMs, signal);
+  }
+}

--- a/src/utils/wait-for-healthz.ts
+++ b/src/utils/wait-for-healthz.ts
@@ -3,7 +3,8 @@ import http from 'http';
 export interface WaitForHealthzOptions {
   /** Delay between poll attempts in milliseconds. Default: 50. */
   intervalMs?: number;
-  /** Abort to stop polling; the returned promise rejects when aborted. */
+  /** Abort to stop polling; the returned promise rejects when aborted. Supply a
+   * timeout-backed signal so a half-open connection cannot hang indefinitely. */
   signal?: AbortSignal;
 }
 
@@ -13,6 +14,9 @@ const DEFAULT_INTERVAL_MS = 50;
 async function probeOnce(url: string, signal?: AbortSignal): Promise<boolean> {
   return await new Promise<boolean>((resolve) => {
     const request = http.get(url, { signal }, (response) => {
+      response.on(`error`, () => {
+        // Ignore late stream errors during/after drain; the status is captured.
+      });
       const status = response.statusCode ?? 0;
       response.resume(); // drain so the socket frees promptly
       resolve(status >= 200 && status < 300);


### PR DESCRIPTION
## Summary

Adds an **opt-in HTTP monitoring port** to `NatsServer`, uses `GET /healthz` for **deterministic readiness** when it is enabled, and adds a **bounded start timeout** so `start()` can never hang forever. Monitoring is **off by default**, so existing behavior is unchanged except that `start()` is now time-bounded.

This is step "B" of a larger growth roadmap; the client-port race, orphan-process cleanup, and `stop()` timeout are intentionally deferred to later steps.

## What changed

**Public API**
- Builder: `enableMonitoring()`, `disableMonitoring()`, `setMonitoringPort(port)`, `setStartTimeout(ms)` (monitoring setters are last-call-wins).
- `NatsServer.getMonitoringUrl(): string | undefined` — `http://<host>:<monitorPort>` when monitoring is enabled **and** `start()` resolved; otherwise `undefined`.
- Config-file options: `monitoring?: boolean | number` and `startTimeoutMs?: number` (precedence: defaults < config file < explicit code).

**Behavior**
- When monitoring is enabled, `-m <port>` is passed to `nats-server` (a free port is auto-allocated unless an explicit one is set) and readiness is decided by polling `/healthz` via Node's built-in `http` (no proxy, no new dependency). When bound to `0.0.0.0`, the probe targets `127.0.0.1`.
- When monitoring is off, readiness still uses the stderr `Server is ready` scan — now bounded by `startTimeoutMs` (default `30000`).
- A single `AbortController` + `unref()`'d timer drives both paths and is cleared/aborted on every settlement path (resolve / timeout / spawn error / close); a `settled` flag guarantees `start()` settles exactly once. Failure errors now include a short tail of recent stderr for diagnostics.

**Default-off guarantee:** the monitoring-off spawn args stay exactly `['--addr', ip, '--port', port, ...args]` (existing exact-args tests are untouched).

## Files
- `src/utils/wait-for-healthz.ts` (new) — local `/healthz` poller.
- `src/nats-server.ts` — options/defaults, `pickRuntimeOptions`, `start()` rewrite, `getMonitoringUrl()`.
- `src/nats-server.builder.ts` — four new setters.
- `src/utils/get-project-config.ts` — config-file fields.
- `README.md` — Monitoring & readiness section.
- `docs/superpowers/specs/…` and `docs/superpowers/plans/…` — design spec and implementation plan.

## Testing
- `npm test`: **93/93 passing across 10 suites.**
- New coverage: `waitForHealthz` (resolve/retry/abort, real local http server); monitoring-enabled start via `/healthz` + `getMonitoringUrl` (mocked spawn and real-binary integration); start-timeout rejection; `getMonitoringUrl` undefined after a failed monitoring start; `0.0.0.0` → `127.0.0.1` probe mapping; stderr tail in the timeout error.
- Verified against the real `nats-server` v2.9.16 binary: `-m`/`--http_port`, `/healthz` → `200 {"status":"ok"}`, monitor binds to the `--addr` host.

## Notes
- Out of scope (future steps): client-port TOCTOU race, orphan-process cleanup on abnormal exit, `stop()` timeout + SIGKILL escalation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)