### PR TITLE
Refine lint-staged configuration for better linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,12 @@
     "automation"
   ],
   "lint-staged": {
-    "src/**/*.{js,ts,json}": [
-      "eslint . --fix",
-      "prettier --write ."
+    "*.ts": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{js,json,md,yml,yaml}": [
+      "prettier --write"
     ]
   },
   "author": "Llirik1337",


### PR DESCRIPTION
## Summary
Updated the lint-staged configuration to apply linting and formatting tools more selectively based on file type, improving the efficiency and clarity of the pre-commit workflow.

## Key Changes
- Split the single glob pattern into two separate configurations:
  - TypeScript files (`*.ts`): Run both ESLint and Prettier
  - Other files (`*.{js,json,md,yml,yaml}`): Run Prettier only
- Simplified ESLint and Prettier commands by removing the `.` argument (uses default behavior)
- Removed the `src/` directory prefix from glob patterns for broader coverage

## Implementation Details
This change allows TypeScript files to benefit from ESLint's type-aware linting while other file types are formatted with Prettier only, avoiding unnecessary linting overhead for non-TypeScript files. The configuration is now more explicit about which tools apply to which file types.

https://claude.ai/code/session_012bXpseR9EeRKWM89LtRcmW