### PR TITLE
fix: prevent concurrent start() from spawning a second, orphaned server

### DIFF
--- a/src/nats-server.spec.ts
+++ b/src/nats-server.spec.ts
@@ -257,4 +257,37 @@ describe(NatsServer.name, () => {
       spawnSpy.mockRestore();
     }
   });
+
+  it(`spawns only once when start() is called concurrently`, async () => {
+    const spawnSpy = jest
+      .spyOn(child_process, `spawn`)
+      .mockImplementation(() => makeFloodingChild());
+
+    try {
+      const server = new NatsServer({
+        ...DEFAULT_NATS_SERVER_OPTIONS,
+        verbose: false,
+        port: 4222,
+        binPath: `fake-nats-server`,
+      });
+
+      // Both calls race before this.process is assigned; the in-flight guard
+      // must collapse them into a single spawn and resolve both to the same
+      // instance — otherwise the second spawn orphans a child whose handle
+      // stop() can never reach.
+      const [a, b] = await withTimeout(
+        Promise.all([server.start(), server.start()]),
+        3000,
+        `concurrent start()`,
+      );
+
+      expect(spawnSpy).toHaveBeenCalledTimes(1);
+      expect(a).toBe(server);
+      expect(b).toBe(server);
+
+      await server.stop();
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
 });

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -74,7 +74,7 @@ export class NatsServer {
   /** The in-flight start() promise. Established synchronously at the top of
    * start() so concurrent/re-entrant calls share one spawn instead of racing
    * past the `this.process == null` guard — this.process is not assigned until
-   * spawnServer() spawns, after its awaits. */
+   * _start() spawns, after its awaits. */
   private startPromise?: Promise<this>;
 
   constructor(private readonly options: Partial<NatsServerOptions> = {}) {}
@@ -105,7 +105,7 @@ export class NatsServer {
       return await this.startPromise;
     }
 
-    const startPromise = this.spawnServer();
+    const startPromise = this._start();
     this.startPromise = startPromise;
 
     try {
@@ -116,7 +116,7 @@ export class NatsServer {
     }
   }
 
-  private async spawnServer(): Promise<this> {
+  private async _start(): Promise<this> {
     // getProjectConfig memoizes per project path (and no longer caches a
     // rejection), so calling it directly each start() is both cheap and
     // recoverable — no separate static promise cache is needed here.

--- a/src/nats-server.ts
+++ b/src/nats-server.ts
@@ -71,9 +71,52 @@ export class NatsServer {
    * observe the same `verbose`/`logger`. */
   private resolvedOptions?: NatsServerOptions;
 
+  /** The in-flight start() promise. Established synchronously at the top of
+   * start() so concurrent/re-entrant calls share one spawn instead of racing
+   * past the `this.process == null` guard — this.process is not assigned until
+   * spawnServer() spawns, after its awaits. */
+  private startPromise?: Promise<this>;
+
   constructor(private readonly options: Partial<NatsServerOptions> = {}) {}
 
   async start(): Promise<this> {
+    // Already running: a previous start() resolved and set this.process. Read
+    // verbose/logger from the options that start actually ran with.
+    if (this.process != null) {
+      const { verbose, logger } = this.resolvedOptions ?? {
+        ...DEFAULT_NATS_SERVER_OPTIONS,
+        ...this.options,
+      };
+      const message = `Nats server already started at ${this.getUrl()}`;
+
+      if (verbose) {
+        logger.warn(message);
+      }
+
+      return this;
+    }
+
+    // A start() is already in flight (e.g. Promise.all([s.start(), s.start()])
+    // or a re-entrant call before the first resolved). Share that promise: the
+    // guard above can't catch a concurrent caller because this.process is not
+    // assigned until spawnServer() spawns — after its awaits — so without this
+    // a second caller would spawn a second, orphaned child.
+    if (this.startPromise != null) {
+      return await this.startPromise;
+    }
+
+    const startPromise = this.spawnServer();
+    this.startPromise = startPromise;
+
+    try {
+      return await startPromise;
+    } finally {
+      // Clear so a later start() (after stop() or a crash) can spawn afresh.
+      this.startPromise = undefined;
+    }
+  }
+
+  private async spawnServer(): Promise<this> {
     // getProjectConfig memoizes per project path (and no longer caches a
     // rejection), so calling it directly each start() is both cheap and
     // recoverable — no separate static promise cache is needed here.
@@ -91,30 +134,20 @@ export class NatsServer {
     this.resolvedOptions = config;
 
     const { verbose, logger } = config;
-
-    if (this.process != null) {
-      const message = `Nats server already started at ${this.getUrl()}`;
-
-      if (verbose) {
-        logger.warn(message);
-      }
-
-      return this;
-    }
-
     const { args, ip, port = await getFreePort(), binPath } = config;
 
     if (binPath == null) {
       throw new Error(`Could not resolve a binPath for the NATS server binary`);
     }
 
-    return await new Promise((resolve, reject) => {
-      this.process = child_process.spawn(
+    return await new Promise<this>((resolve, reject) => {
+      const child = child_process.spawn(
         binPath,
         [`--addr`, ip, `--port`, port.toString(), ...args],
         { stdio: `pipe` },
       );
 
+      this.process = child;
       this.host = ip;
       this.port = port;
 
@@ -123,24 +156,28 @@ export class NatsServer {
       // wait for the readiness line on stderr. nats-server itself logs to
       // stderr, but we don't control what a custom binPath prints. We don't
       // need stdout's contents, so just let it flow and discard.
-      this.process.stdout.resume();
+      child.stdout.resume();
 
       let isReady = false;
 
-      this.process.once(`error`, (err) => {
+      child.once(`error`, (err) => {
         if (verbose) {
           logger.error(`NATS server error:`, err);
         }
 
         // Only fail the start Promise if we never became ready; a transient
         // error after readiness must not tear down a running server's handle.
+        // Clear the handle only if it still points at our child, so a failed
+        // spawn cannot wipe a handle a later start() already installed.
         if (!isReady) {
-          this.process = undefined;
+          if (this.process === child) {
+            this.process = undefined;
+          }
           reject(err);
         }
       });
 
-      this.process.stderr.on(`data`, (data: unknown) => {
+      child.stderr.on(`data`, (data: unknown) => {
         // Once ready, non-verbose mode has nothing left to do on this stream,
         // so skip the work entirely for high-volume logs.
         if (isReady && !verbose) {
@@ -174,16 +211,20 @@ export class NatsServer {
               logger.log(`NATS server is ready!`);
             }
             resolve(this);
-            this.process?.unref();
+            child.unref();
           }
         }
       });
 
-      this.process.once(`close`, (code) => {
+      child.once(`close`, (code) => {
         // The child has exited: clear the handle so a later stop() does not
         // kill() a dead process (which never re-emits `close`, hanging stop())
-        // and so start() can spawn a fresh server on a subsequent call.
-        this.process = undefined;
+        // and so start() can spawn a fresh server on a subsequent call. Guard
+        // on identity so a second, failed spawn's close can't clear the handle
+        // of a healthy server a later start() already installed.
+        if (this.process === child) {
+          this.process = undefined;
+        }
 
         if (verbose) {
           logger.log(`NATS server was stop!`);


### PR DESCRIPTION
## What

`NatsServer.start()` has a TOCTOU race. The `if (this.process != null)` re-entry
guard runs **after** `await getProjectConfig(...)`, but `this.process` is not
assigned until the `spawn` that follows another `await` (`getFreePort()`). Two
overlapping `start()` calls — `Promise.all([s.start(), s.start()])`, or a
re-entrant call before the first resolves — therefore both pass the guard and
both spawn.

Consequences:
- The second handle clobbers the first → the first `nats-server` process is
  orphaned and `stop()` can never kill it.
- With a fixed port, the second spawn fails to bind and its `close` handler
  nulls out the handle of the first, healthy server.

## Fix

- Establish an in-flight `startPromise` **synchronously** at the top of
  `start()`; concurrent/re-entrant callers `await` the same promise instead of
  racing.
- Extract config resolution + spawn into a private `spawnServer()`. The "already
  started" guard now reads `verbose`/`logger` from `resolvedOptions`.
- In the `error`/`close` handlers, clear `this.process` only when it still
  references their own `child` (`if (this.process === child)`), so a failed
  second spawn can't wipe a healthy handle.

## Test

Added a regression test that spies on `child_process.spawn` and asserts a single
spawn under `Promise.all([s.start(), s.start()])`, both calls resolving to the
same instance. Verified red→green on `main` (before: spawn called 2×; after: 1×).

`tsc` ✅ · `eslint` ✅ · `jest` ✅ (9 suites / 77 tests).

## Context

This came out of a full code review of the project. The review also flagged a
config-loader bug (a `nats-memory-server.ts`/`.js` written with `export default`
was silently ignored), but `main` already fixes that via `unwrapDefaultExport`
(with tests), so it is intentionally **not** included here — this PR is scoped to
the concurrency race only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
